### PR TITLE
PR: Fix actionlint install script to use version parameter instead of `-b` flag in workflow

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           npm install --no-save markdownlint-cli ajv ajv-formats yaml
           pipx install yamllint
-          curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- -b $HOME/bin
+          curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s latest $HOME/bin
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Changed files


### PR DESCRIPTION
---
name: "Pull Request"
about: "General changes, refactors, and maintenance"
title: "PR: Fix actionlint install script to use version parameter instead of `-b` flag in workflow"
labels: ["status:needs-review"]
---

# General Pull Request

The actionlint download script expects a version number (such as `latest`) followed by an optional directory path, not a `-b` flag.  
This PR updates the install invocation from:

```bash
bash -s -- -b $HOME/bin
```

to

```bash
bash -s latest $HOME/bin
```

so that `latest` is correctly passed as the version number and the bin directory is set as intended.  
This resolves workflow failures where the script previously received `-b` as the version parameter, triggering install errors.

> This repository enforces changelog, release, and label automation for all PRs and issues.  
> See the organization-wide [Automation Governance & Release Strategy](https://github.com/lightspeedwp/.github/blob/main/AUTOMATION_GOVERNANCE.md) for contributor rules.

## Linked issues

<!--
List any related issues by number (e.g. closes #123, fixes #456, relates to #789).
-->

<!-- No related issues. -->

## Changelog

<!--
Required for release automation.
Format: Keep a Changelog.
Categories: Added, Changed, Fixed, Removed.
User-facing notes only. Internal-only PRs (rare) may use the skip-changelog label.
-->

### Fixed

- Fix actionlint workflow install script to properly pass the version number, resolving a setup error where `-b` was incorrectly interpreted as the version argument.

---

## Risk Assessment

**Risk Level:** Low

**Potential Impact:**
- Minimal: The change is limited to the CI workflow script and only affects the manner in which actionlint is downloaded and installed.

**Mitigation Steps:**
- Validated syntax and parameters based on the official install documentation.
- Tested the update in a separate environment to confirm correct script execution.

---

## How to Test

### Prerequisites

- Use a repository branch containing these workflow changes.

### Test Steps

1. **Push the updated workflow to a feature branch.**
   - Expected: The CI workflow proceeds past the actionlint install step without error.

2. **Observe the step where actionlint is downloaded and installed.**
   - Expected: The install script fetches the latest version and sets up the bin directory without failure.

3. **If other workflow steps depend on actionlint, verify their success.**
   - Expected: Linters and subsequent tasks using actionlint should function as intended.

### Expected Results

- The workflow runs successfully with actionlint installed, no errors due to incorrect script parameters.

### Edge Cases to Verify

- [ ] CI runs on both `push` and `pull_request` events.
- [ ] Workflow still functions with explicit version numbers (e.g., `bash -s v1.7.0 $HOME/bin`).

---

### Checklist (Global DoD / PR)

- [ ] All AC met and demonstrated
- [ ] Tests added/updated (unit/E2E as appropriate)
- [ ] A11y considerations addressed where relevant
- [ ] Docs/readme/changelog updated (if user-facing)
- [ ] Security/perf impact reviewed where relevant
- [ ] Code/design reviews approved
- [ ] CI green; linked issues closed; release notes prepared (if shipping)
- [ ] Risk assessment completed above
- [ ] Testing instructions provided above

---

## References

- [Contribution Guidelines](../CONTRIBUTING.md)
- [Branching Strategy](.github/BRANCHING_STRATEGY.md)
- [Automation Governance](.github/AUTOMATION_GOVERNANCE.md)
- [PR Labels](.github/PR_LABELS.md)
- [Saved Replies](.github/SAVED_REPLIES.md)
- [Project Meta](.github/PROJECT_META.md)
- [Labeler Config](.github/labeler.yml)
- [Labels](.github/labels.yml)
- [Issue Types](.github/issue-types.yml)

---