### PR TITLE
fix: command-gate release workflow and harden permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,80 @@ name: release
 on:
   workflow_dispatch:
     inputs:
-      scope:
-        description: "Comma-separated package scope (optional)"
+      version:
+        description: "Target release version (semver, e.g. 1.2.3). Leave blank to derive from scope."
         required: false
         default: ""
+        type: string
+      notes_from:
+        description: "Git ref/tag/sha to start release notes range from (optional)."
+        required: false
+        default: ""
+        type: string
+      scope:
+        description: "Version bump scope if version is not provided (major|minor|patch)."
+        required: false
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: "Run safety mode without creating commits/tags/releases."
+        required: false
+        default: true
+        type: boolean
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        default: ""
+        type: string
+      notes_from:
+        required: false
+        default: ""
+        type: string
+      scope:
+        required: false
+        default: "patch"
+        type: string
+      dry_run:
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
 
 jobs:
+  trigger-telemetry:
+    runs-on: ubuntu-latest
+    outputs:
+      unauthorized_attempts: ${{ steps.telemetry.outputs.unauthorized_attempts }}
+    steps:
+      - id: telemetry
+        name: Record trigger telemetry
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ github.event_name }}" in
+            workflow_dispatch|workflow_call) unauthorized_attempts=0 ;;
+            *) unauthorized_attempts=1 ;;
+          esac
+          echo "unauthorized_attempts=${unauthorized_attempts}" >> "$GITHUB_OUTPUT"
+          cat > trigger-telemetry.json <<EOF
+          {"event":"${{ github.event_name }}","actor":"${{ github.actor }}","unauthorized_attempts":${unauthorized_attempts}}
+          EOF
+      - name: Upload telemetry artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trigger-telemetry
+          path: trigger-telemetry.json
+
   lint:
+    needs: [trigger-telemetry]
+    if: needs.trigger-telemetry.outputs.unauthorized_attempts == '0'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,12 +116,48 @@ jobs:
       - name: Run Release Agent
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_SCOPE: ${{ inputs.scope || github.event.inputs.scope || 'patch' }}
+          INPUT_VERSION: ${{ inputs.version || github.event.inputs.version || '' }}
+          INPUT_NOTES_FROM: ${{ inputs.notes_from || github.event.inputs.notes_from || '' }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          SCOPE_INPUT="${{ github.event.inputs.scope }}"
-          if [ -z "$SCOPE_INPUT" ]; then
-            SCOPE_INPUT="patch"
+          set -euo pipefail
+          if [ -z "${INPUT_SCOPE}" ]; then
+            INPUT_SCOPE="patch"
           fi
-          node scripts/agents/release.agent.js --scope="$SCOPE_INPUT"
+          EXTRA_ARGS=""
+          if [ -n "${INPUT_VERSION}" ]; then
+            EXTRA_ARGS="${EXTRA_ARGS} --version=${INPUT_VERSION}"
+          fi
+          if [ -n "${INPUT_NOTES_FROM}" ]; then
+            EXTRA_ARGS="${EXTRA_ARGS} --notes-from=${INPUT_NOTES_FROM}"
+          fi
+          if [ "${INPUT_DRY_RUN}" = "true" ]; then
+            EXTRA_ARGS="${EXTRA_ARGS} --dry-run"
+          fi
+          node scripts/agents/release.agent.js --scope="${INPUT_SCOPE}" ${EXTRA_ARGS} | tee release-agent.log
+      - name: Build dry-run release notes preview
+        if: inputs.dry_run == true
+        shell: bash
+        run: |
+          set -euo pipefail
+          RANGE_START="${{ inputs.notes_from || github.event.inputs.notes_from }}"
+          if [ -z "${RANGE_START}" ]; then
+            RANGE_START="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          fi
+          if [ -n "${RANGE_START}" ]; then
+            git log "${RANGE_START}..develop" --first-parent --pretty=format:"- %h %s" > release-notes-preview.md
+          else
+            git log develop --first-parent --pretty=format:"- %h %s" > release-notes-preview.md
+          fi
+      - name: Upload dry-run artefacts
+        if: inputs.dry_run == true
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dry-run-artefacts
+          path: |
+            release-agent.log
+            release-notes-preview.md
       - name: Post metrics
         if: always()
         run: echo "metric=release_cycle conclusion=${{ job.status }}"

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -41,10 +41,13 @@ references:
     - `CHANGELOG.md` conforms to `changelog.schema.json`.
     - Unreleased section exists and is populated.
 - **Release workflow (`.github/workflows/release.yml`)**
-  - Manual `workflow_dispatch` (scope input, default patch).
+  - Manual `workflow_dispatch` and reusable `workflow_call`.
+  - Typed inputs: `version`, `notes_from`, `scope`, `dry_run`.
   - Hard gate on lint (`linting.yml` reuse).
   - Runs schema + unreleased validation before invoking `release.agent.js`.
   - Uses `release.agent.js` (ESM) to create release branch, PR → `main`, tag, and GitHub Release with compiled notes.
+  - Dry-run mode publishes review artefacts (`release-agent.log`, `release-notes-preview.md`) without creating commits/tags/releases.
+  - Trigger telemetry records unauthorised trigger attempts (expected `0`).
 - **Required checks before merging release PR**
   - Lint/test green.
   - Changelog validation green.
@@ -106,6 +109,19 @@ node scripts/agents/release.agent.js --scope=minor --dry-run
 - **No unreleased changes:** add entries under `[Unreleased]` before running release agent.
 - **PR not created:** ensure `gh` CLI and `GITHUB_TOKEN` available; otherwise create PR from `release/vX.Y.Z` → `main` manually.
 - **Tag conflicts:** delete or move existing tag before rerunning; ensure working tree clean.
+
+## Rollback notes
+
+If a release is started but must be rolled back:
+
+1. Delete the release branch (`release/vX.Y.Z`) if it should not proceed.
+2. Delete the tag locally and remotely:
+   - `git tag -d vX.Y.Z`
+   - `git push origin :refs/tags/vX.Y.Z`
+3. If a GitHub Release was created, remove it:
+   - `gh release delete vX.Y.Z --yes`
+4. Restore `VERSION` and `CHANGELOG.md` to the last known good commit on `develop`.
+5. Re-run the workflow in `dry_run` mode first to validate fixes before re-attempting a live release.
 
 ---
 

--- a/scripts/agents/release.agent.js
+++ b/scripts/agents/release.agent.js
@@ -102,6 +102,27 @@ function determineNextVersion(currentVersion, scope = "patch") {
 }
 
 /**
+ * Compare two semver strings.
+ * @param {string} leftVersion - Left version
+ * @param {string} rightVersion - Right version
+ * @returns {number} -1 if left < right, 0 if equal, 1 if left > right
+ */
+function compareVersions(leftVersion, rightVersion) {
+  const left = parseVersion(leftVersion);
+  const right = parseVersion(rightVersion);
+  if (!left || !right) {
+    throw new Error(
+      `Cannot compare invalid versions: ${leftVersion}, ${rightVersion}`,
+    );
+  }
+
+  if (left.major !== right.major) return left.major > right.major ? 1 : -1;
+  if (left.minor !== right.minor) return left.minor > right.minor ? 1 : -1;
+  if (left.patch !== right.patch) return left.patch > right.patch ? 1 : -1;
+  return 0;
+}
+
+/**
  * Fetch merged PRs between two tags (inclusive of toTag)
  */
 function getMergedPRs(fromTag, toTag = "HEAD") {
@@ -230,6 +251,7 @@ function formatReleaseNotes(options = {}) {
   const {
     version,
     changelogPath = "CHANGELOG.md",
+    notesFrom = "",
     includeContributors = true,
     includeBreakingChanges = true,
     includeHighlights = true,
@@ -254,8 +276,9 @@ function formatReleaseNotes(options = {}) {
     currentIndex >= 0 && currentIndex < tags.length - 1
       ? tags[currentIndex + 1]
       : null;
+  const rangeStart = notesFrom || previousTag;
 
-  const prs = getMergedPRs(previousTag, currentTag);
+  const prs = getMergedPRs(rangeStart, currentTag);
   const contributors = getContributors(prs);
   const breakingChanges = includeBreakingChanges
     ? detectBreakingChanges(changelogData, version)
@@ -335,8 +358,8 @@ function formatReleaseNotes(options = {}) {
 
   notes += "---\n\n";
   notes += "**Full Changelog**: ";
-  if (previousTag) {
-    notes += `[\`${previousTag}...v${version}\`](../../compare/${previousTag}...v${version})\n`;
+  if (rangeStart) {
+    notes += `[\`${rangeStart}...v${version}\`](../../compare/${rangeStart}...v${version})\n`;
   } else {
     notes += `[View all changes](../../commits/v${version})\n`;
   }
@@ -526,12 +549,20 @@ function pushChanges(options = {}) {
  * @param {Object} options - Options
  */
 function createRelease(version, options = {}) {
-  const { changelogPath = "CHANGELOG.md", dryRun = false } = options;
+  const {
+    changelogPath = "CHANGELOG.md",
+    dryRun = false,
+    notesFrom = "",
+  } = options;
 
   console.log(`\n=== Creating GitHub Release for v${version} ===`);
 
   // Extract release notes from changelog
-  const releaseNotes = formatReleaseNotes({ version, changelogPath });
+  const releaseNotes = formatReleaseNotes({
+    version,
+    changelogPath,
+    notesFrom,
+  });
 
   // TODO (c): Harden GitHub release/tag creation with retries, templated notes, and PR gating before publishing.
 
@@ -597,7 +628,11 @@ async function run() {
     const dryRun =
       args.includes("--dry-run") || args.includes("--dry-run=true");
     const scopeArg = args.find((arg) => arg.startsWith("--scope="));
+    const versionArg = args.find((arg) => arg.startsWith("--version="));
+    const notesFromArg = args.find((arg) => arg.startsWith("--notes-from="));
     const scope = scopeArg ? scopeArg.split("=")[1] : "patch";
+    const explicitVersion = versionArg ? versionArg.split("=")[1] : "";
+    const notesFrom = notesFromArg ? notesFromArg.split("=")[1] : "";
 
     console.log("╔════════════════════════════════════════╗");
     console.log("║     LightSpeed Release Agent           ║");
@@ -605,6 +640,12 @@ async function run() {
     console.log("");
     console.log(`Mode: ${dryRun ? "DRY-RUN" : "LIVE"}`);
     console.log(`Scope: ${scope}`);
+    if (explicitVersion) {
+      console.log(`Target Version: ${explicitVersion}`);
+    }
+    if (notesFrom) {
+      console.log(`Release Notes Start: ${notesFrom}`);
+    }
     // TODO (d): Clarify dry-run vs apply controls (additional flags or safeguards) so we can safely exercise the workflow end-to-end.
     console.log("");
 
@@ -626,7 +667,21 @@ async function run() {
 
     // Step 2: Determine next version
     const currentVersion = fs.readFileSync("VERSION", "utf8").trim();
-    const nextVersion = determineNextVersion(currentVersion, scope);
+    let nextVersion = determineNextVersion(currentVersion, scope);
+    if (explicitVersion) {
+      const versionResult = validateVersion(explicitVersion);
+      if (!versionResult.valid) {
+        throw new Error(
+          `Invalid explicit version "${explicitVersion}": ${versionResult.error}`,
+        );
+      }
+      if (compareVersions(explicitVersion, currentVersion) <= 0) {
+        throw new Error(
+          `Explicit version ${explicitVersion} must be greater than current version ${currentVersion}`,
+        );
+      }
+      nextVersion = explicitVersion;
+    }
     const releaseBranch = `release/v${nextVersion}`;
 
     console.log(`\nVersion bump: ${currentVersion} → ${nextVersion}`);
@@ -638,7 +693,6 @@ async function run() {
     } else {
       console.log(`[DRY-RUN] Would create branch ${releaseBranch}`);
     }
-
 
     // Step 3: Bump version
     bumpVersion(nextVersion, { dryRun });
@@ -667,7 +721,7 @@ async function run() {
     createReleasePR(nextVersion, releaseBranch, { dryRun });
 
     // Step 8: Create GitHub Release
-    createRelease(nextVersion, { dryRun });
+    createRelease(nextVersion, { dryRun, notesFrom });
 
     console.log("\n");
     console.log("╔════════════════════════════════════════╗");


### PR DESCRIPTION
## Summary
- restrict release workflow usage to workflow_dispatch/workflow_call with typed inputs
- add dry-run artefacts and trigger telemetry for release runs
- extend release agent to accept explicit version and notes_from controls

Closes #70