### PR TITLE
docs: define downstream override policy for org defaults

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -143,6 +143,7 @@ Include:
   - [ ] ARIA used only where needed
   - [ ] Contrast and non-colour cues reviewed (WCAG 2.2 AA)
 - [ ] Docs/readme/changelog updated (if user-facing)
+- [ ] I have reviewed and applied the downstream override policy (or linked an approved exception)
 - [ ] Security checklist completed (where relevant):
   - [ ] Untrusted input validated and sanitised
   - [ ] Output escaped for its rendering context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -162,7 +162,7 @@ Include:
 - [Branching Strategy](../docs/BRANCHING_STRATEGY.md)
 - [Automation Governance](../docs/AUTOMATION_GOVERNANCE.md)
 - [PR Labels](../docs/PR_LABELS.md)
-- [Saved Replies](./SAVED_REPLIES.md)
+- [Saved Replies](./SAVED_REPLIES/README.md)
 - [Labeler Config](./labeler.yml)
 - [Labels](./labels.yml)
 - [Issue Types](./issue-types.yml)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a canonical shared `.github` adoption guide with required, recommended,
   optional, and repo-local-only classifications, plus update and validation
   workflows for consuming repositories.
+- Added a downstream override policy document for org defaults and linked it
+  from contribution and docs index pages to support repository-level adoption
+  decisions.
 
 ## [0.3.0] - 2025-12-18
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,7 @@ Refer to `.vscode/extensions.json` and `.vscode/settings.json` for the authorita
 - **Saved Replies:** Use [SAVED_REPLIES.md](.github/SAVED_REPLIES.md) for common responses and efficient communication.
 - **Documentation:** Update relevant docs (README, instructions) for any user-facing change.
 - **Automation & Labels:** Ensure your issue/PR complies with [AUTOMATION_GOVERNANCE.md](./docs/AUTOMATION_GOVERNANCE.md), [ISSUE_LABELS.md](docs/ISSUE_LABELS.md), and [ISSUE_TYPES.md](./docs/ISSUE_TYPES.md).
+- **Downstream overrides:** If you are adopting org defaults in another repository, follow [Downstream Override Policy](./docs/override-policy.md) and link any approved exception.
 - **Changelog:** All user-facing changes, fixes, and features must be entered in [CHANGELOG.md](./CHANGELOG.md) in Keep a Changelog format. See example sections in the changelog for proper grouping and linking.
 
 ---
@@ -139,6 +140,7 @@ Refer to `.vscode/extensions.json` and `.vscode/settings.json` for the authorita
 - [BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md): Org-wide branch naming, merge discipline, and automation mapping.
 - [CHANGELOG.md](./CHANGELOG.md): Changelog format, release notes, and versioning.
 - [AUTOMATION_GOVERNANCE.md](./docs/AUTOMATION_GOVERNANCE.md): Org-wide automation, branching, label, and release strategy.
+- [override-policy.md](./docs/override-policy.md): Mandatory versus optional org defaults, exception handling, and promotion model.
 - [ISSUE_TYPES.md](./docs/ISSUE_TYPES.md): Issue type mapping and usage.
 - [ISSUE_LABELS.md](./docs//ISSUE_LABELS.md): Label families, triage, and workflow.
 - [PR_LABELS.md](./docs//PR_LABELS.md): PR labeling, templates, and automation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ To maintain a consistent, high-quality codebase and community, please follow the
   - For features/enhancements: describe the problem/opportunity, proposed solution, mockups/designs, and acceptance criteria.
   - For other types: explain context, goals, action items, and impact.
 - **Reference relevant docs or standards:**
-  See [Coding Standards](instructions/coding-standards.instructions.md), [Pattern Development](.github/instructions/block-theme/pattern-development.instructions.md), [Theme JSON](.github/instructions/theme-json.instructions.md), etc.
+  See [Coding Standards](instructions/coding-standards.instructions.md), [Documentation Formats](instructions/documentation-formats.instructions.md), and [Languages & Linting](instructions/languages.instructions.md).
 - **Outline your planned approach for complex issues** and request feedback before implementation.
 - **Automation:** Well-formed issues using the right template are automatically labeled, routed, and prioritized.
 
@@ -127,7 +127,7 @@ To ensure a consistent development experience and code quality, all contributors
 
 Refer to `.vscode/extensions.json` and `.vscode/settings.json` for the authoritative list and configuration.
 
-- **Saved Replies:** Use [SAVED_REPLIES.md](.github/SAVED_REPLIES.md) for common responses and efficient communication.
+- **Saved Replies:** Use [SAVED_REPLIES/README.md](.github/SAVED_REPLIES/README.md) for common responses and efficient communication.
 - **Documentation:** Update relevant docs (README, instructions) for any user-facing change.
 - **Automation & Labels:** Ensure your issue/PR complies with [AUTOMATION_GOVERNANCE.md](./docs/AUTOMATION_GOVERNANCE.md), [ISSUE_LABELS.md](docs/ISSUE_LABELS.md), and [ISSUE_TYPES.md](./docs/ISSUE_TYPES.md).
 - **Downstream overrides:** If you are adopting org defaults in another repository, follow [Downstream Override Policy](./docs/override-policy.md) and link any approved exception.
@@ -145,8 +145,8 @@ Refer to `.vscode/extensions.json` and `.vscode/settings.json` for the authorita
 - [ISSUE_LABELS.md](./docs//ISSUE_LABELS.md): Label families, triage, and workflow.
 - [PR_LABELS.md](./docs//PR_LABELS.md): PR labeling, templates, and automation.
 - [Coding Standards](instructions/coding-standards.instructions.md)
-- [Pattern Development](.github/instructions/block-theme/pattern-development.instructions.md)
-- [Theme JSON](.github/instructions/theme-json.instructions.md)
+- [Documentation Formats](instructions/documentation-formats.instructions.md)
+- [Languages & Linting](instructions/languages.instructions.md)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,5 +15,6 @@ Central index for all documentation in the LightSpeed .github repository.
 
 - [Shared .github Adoption Guide](./SHARED_GITHUB_ADOPTION_GUIDE.md)
 - [Migration Notes](./MIGRATION.md)
+- [Downstream Override Policy](./override-policy.md)
 
 *Docs signed by 🤖 Copilot for LightSpeedWP – always fresh!*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+---
+version: "v0.1.0"
+last_updated: "2026-05-27"
+owners: ["lightspeedwp"]
+file_type: "index"
+category: "documentation"
+description: "Canonical index entrypoint for docs, forwarding to docs/README.md."
+---
+
+# Documentation Index
+
+Use the primary docs hub:
+
+- [Documentation Hub](./README.md)
+- [Downstream Override Policy](./override-policy.md)

--- a/docs/override-policy.md
+++ b/docs/override-policy.md
@@ -1,0 +1,105 @@
+---
+title: "Downstream Override Policy For Organisation Defaults"
+description: "Policy defining mandatory and optional organisation defaults for downstream repositories, including exceptions, versioning, and promotion."
+version: "v0.1.0"
+last_updated: "2026-05-27"
+owners: ["LightSpeed Team"]
+tags: ["governance", "policy", "adoption", "override", "documentation"]
+domain: "governance"
+stability: "active"
+references:
+  - path: "SHARED_GITHUB_ADOPTION_GUIDE.md"
+    description: "Adoption process and practical implementation guidance"
+  - path: "AUTOMATION_GOVERNANCE.md"
+    description: "Organisation automation and governance standards"
+  - path: "../instructions/file-organisation.instructions.md"
+    description: "Canonical placement and boundary guidance"
+---
+
+# Downstream Override Policy For Organisation Defaults
+
+## Scope
+
+This policy defines how downstream LightSpeed repositories adopt organisation
+defaults published from this `.github` repository, and where local overrides
+are allowed.
+
+This policy applies to:
+
+- Community health files (issue and pull request templates, support, security,
+  and conduct).
+- GitHub governance defaults (labels, issue types, triage conventions, and
+  governance-aligned docs).
+- Shared adoption guidance for repository maintainers.
+
+This policy does not replace repository-specific implementation rules, product
+architecture, or runtime behaviour decisions.
+
+## Mandatory Vs Optional
+
+Downstream repositories must inherit mandatory defaults unless an approved
+exception is recorded.
+
+| Default Area | Default Source | Requirement | Local Override Policy |
+| --- | --- | --- | --- |
+| Community health baseline (`CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, contributing flow) | `.github` root canonical files | Mandatory | Allowed only with approved exception and documented legal or operational reason. |
+| Pull request and issue template structure | `.github/PULL_REQUEST_TEMPLATE*`, `.github/ISSUE_TEMPLATE/*` | Mandatory | Local wording and examples may be adjusted; required sections and governance checks must remain. |
+| Label families and issue type schema shape | `.github/labels.yml`, `.github/issue-types.yml` | Mandatory | Repository-specific additive labels are allowed; canonical families and schema contract cannot be removed. |
+| Workflow governance controls | `docs/AUTOMATION_GOVERNANCE.md` plus workflow defaults | Mandatory | Local workflow steps may extend checks; governance gates and security guardrails must not be weakened. |
+| Instruction and documentation implementation detail | `instructions/*`, `docs/*` guidance | Optional with constraints | Repositories may add stricter local rules when they do not conflict with mandatory governance controls. |
+| Repository-specific delivery logic | Local repository codebase | Optional | Fully overrideable; must still meet security, accessibility, and quality standards. |
+
+## Requesting Exceptions
+
+Use this process for any deviation from a mandatory default:
+
+1. Open a governance issue in `lightspeedwp/.github` with:
+   - downstream repository name and path;
+   - default being overridden;
+   - business or technical reason;
+   - risk assessment and rollback plan;
+   - proposed review date.
+2. Link the downstream pull request and include side-by-side diff evidence.
+3. Obtain approval from maintainers responsible for governance.
+4. Record the approved exception in downstream documentation, including:
+   - rationale;
+   - approval reference (issue and pull request links);
+   - expiry or review checkpoint.
+5. Reconfirm exception validity during major governance version changes.
+
+Emergency exceptions are permitted for production safety or legal obligations,
+but must be backfilled with full documentation within two working days.
+
+## Versioning And Promotion
+
+Policy evolution uses incremental versions with explicit promotion steps:
+
+1. Draft changes on a `docs/*` branch and link a governance issue.
+2. Validate links, formatting, and cross-references before review.
+3. Merge after maintainer approval.
+4. Announce the new version in downstream adoption or release notes.
+5. Allow downstream repositories one adoption cycle to align unless a critical
+   security change requires immediate rollout.
+
+Versioning model:
+
+- `v0.x`: policy is active but still refining edge cases.
+- `v1.0`: policy baseline is stable and expected for all downstream repos.
+- `v1.x`: additive clarifications or tighter controls that remain backward
+  compatible.
+- `v2.0+`: potentially breaking governance changes requiring explicit migration.
+
+## Telemetry
+
+Track downstream adoption acknowledgement with the pull request checkbox:
+
+- `I have reviewed and applied the downstream override policy (or linked an approved exception).`
+
+This checkbox is a governance signal and does not replace reviewer judgement.
+
+## References
+
+- [Shared .github Adoption Guide](./SHARED_GITHUB_ADOPTION_GUIDE.md)
+- [Automation Governance](./AUTOMATION_GOVERNANCE.md)
+- [Contributing](../CONTRIBUTING.md)
+- [Documentation Hub](./README.md)

--- a/docs/override-policy.md
+++ b/docs/override-policy.md
@@ -53,7 +53,7 @@ exception is recorded.
 
 Use this process for any deviation from a mandatory default:
 
-1. Open a governance issue in `lightspeedwp/.github` with:
+1. Open a governance issue in [lightspeedwp/.github](https://github.com/lightspeedwp/.github/issues) with:
    - downstream repository name and path;
    - default being overridden;
    - business or technical reason;


### PR DESCRIPTION
## Summary
- add `docs/override-policy.md` to define downstream override boundaries
- classify mandatory vs optional defaults, exception workflow, and version promotion
- add docs index/discoverability links and PR-template acknowledgement telemetry checkbox

## Linked issue
Closes #71

## Validation
- `npx markdownlint-cli2 docs/override-policy.md docs/index.md docs/README.md CONTRIBUTING.md .github/pull_request_template.md`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Added new Downstream Override Policy documentation for organization defaults
- Updated documentation navigation links across contribution guides and documentation hub
- Enhanced pull request template with additional governance checklist requirement
- Improved documentation index structure and accessibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeedwp/.github/pull/421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->