### PR TITLE
Adoption workstream: point pack to live tracker #416, add legacy refs, bump version

### DIFF
--- a/.github/projects/active/adoption-workstream-2026-05-26/README.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/README.md
@@ -1,8 +1,8 @@
 ---
 title: "Adoption Workstream Pack"
 description: "Execution pack for the next governance adoption workstream."
-version: "v0.1.0"
-last_updated: "2026-05-26"
+version: "v0.1.1"
+last_updated: "2026-05-27"
 file_type: "project"
 maintainer: "LightSpeed Team"
 authors: ["Codex"]
@@ -19,7 +19,11 @@ stability: "active"
 Execute the next governance adoption slice by consolidating reusable `.github`
 asset audit findings into a practical policy, usage guide, and decision record.
 
-## Linked live issues
+## Linked live issue
+
+- [#416](https://github.com/lightspeedwp/.github/issues/416)
+
+## Historical references (closed)
 
 - [#326](https://github.com/lightspeedwp/.github/issues/326)
 - [#327](https://github.com/lightspeedwp/.github/issues/327)

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/children/01-audit-reusable-assets-quality-gate.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/children/01-audit-reusable-assets-quality-gate.md
@@ -2,7 +2,8 @@
 name: "Audit"
 title: "[Audit] Reusable .github assets quality gate"
 labels: [status:needs-audit, priority:important, type:documentation]
-github_issue: "https://github.com/lightspeedwp/.github/issues/326"
+github_issue: "https://github.com/lightspeedwp/.github/issues/416"
+legacy_issue: "https://github.com/lightspeedwp/.github/issues/326"
 ---
 
 ## Scope

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/children/02-define-adoption-policy.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/children/02-define-adoption-policy.md
@@ -2,7 +2,8 @@
 name: "Documentation"
 title: "[Documentation] Define adoption policy"
 labels: [status:needs-triage, priority:important, area:documentation]
-github_issue: "https://github.com/lightspeedwp/.github/issues/327"
+github_issue: "https://github.com/lightspeedwp/.github/issues/416"
+legacy_issue: "https://github.com/lightspeedwp/.github/issues/327"
 ---
 
 ## Scope

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/children/03-write-adoption-guide.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/children/03-write-adoption-guide.md
@@ -2,7 +2,8 @@
 name: "Documentation"
 title: "[Documentation] Write adoption guide"
 labels: [status:needs-triage, priority:important, area:documentation]
-github_issue: "https://github.com/lightspeedwp/.github/issues/328"
+github_issue: "https://github.com/lightspeedwp/.github/issues/416"
+legacy_issue: "https://github.com/lightspeedwp/.github/issues/328"
 ---
 
 ## Scope

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/children/04-assess-minimal-automation.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/children/04-assess-minimal-automation.md
@@ -2,7 +2,8 @@
 name: "Audit"
 title: "[Audit] Assess minimal automation for adoption flow"
 labels: [status:needs-audit, priority:normal, type:automation]
-github_issue: "https://github.com/lightspeedwp/.github/issues/329"
+github_issue: "https://github.com/lightspeedwp/.github/issues/416"
+legacy_issue: "https://github.com/lightspeedwp/.github/issues/329"
 ---
 
 ## Scope

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/children/05-audit-maintenance-ownership-docs.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/children/05-audit-maintenance-ownership-docs.md
@@ -2,7 +2,8 @@
 name: "Audit"
 title: "[Audit] Maintenance ownership documentation alignment"
 labels: [status:needs-audit, priority:important, area:documentation]
-github_issue: "https://github.com/lightspeedwp/.github/issues/330"
+github_issue: "https://github.com/lightspeedwp/.github/issues/416"
+legacy_issue: "https://github.com/lightspeedwp/.github/issues/330"
 ---
 
 ## Scope

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/parents/01-epic-adoption-governance-execution.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/parents/01-epic-adoption-governance-execution.md
@@ -9,7 +9,9 @@ labels: [status:needs-triage, priority:important, type:epic, area:documentation]
 Track execution of the adoption governance slice using already-open issue
 threads and one delivery PR.
 
-## Child issue mapping
+Primary tracker: #416
+
+## Historical child issue mapping (closed)
 
 - #326 Audit reusable `.github` assets
 - #327 Define adoption policy

--- a/.github/projects/active/adoption-workstream-2026-05-26/pull-request-draft.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/pull-request-draft.md
@@ -1,21 +1,21 @@
 ---
 title: "PR Draft: Adoption governance workstream scaffold"
-last_updated: "2026-05-26"
+last_updated: "2026-05-27"
 ---
 
 ## Summary
 
 - Scaffolded the next workstream execution pack under
   `.github/projects/active/adoption-workstream-2026-05-26/`.
-- Mapped active adoption issues (`#326-#330`) into a structured parent/child
-  delivery pack.
+- Linked the pack to the live adoption tracker (`#416`) and marked
+  `#326-#330` as historical closed references.
 - Added ready-to-run scope, acceptance criteria, and rollout sequence.
 
 ## Files added
 
 - Workstream README and execution index
 - Parent epic draft
-- Five child issue drafts mapped to live issues
+- Five child issue drafts retained for historical traceability
 - This PR draft
 
 ## Validation


### PR DESCRIPTION
### Motivation

- Align the adoption workstream scaffold with the active live tracker so the pack reflects the current execution point (`#416`).
- Preserve historical context for previously-open child issues (`#326-#330`) for traceability while consolidating the active tracker.
- Update metadata to reflect the new patch version and last-updated timestamp.

### Description

- Bumped pack metadata in the workstream README to `version: "v0.1.1"` and `last_updated: "2026-05-27"` and replaced the linked issues section to point to `#416` with prior issues listed under historical references. 
- Updated each child issue draft to set `github_issue` to `https://github.com/lightspeedwp/.github/issues/416` and added `legacy_issue` fields referencing their original issue URLs. 
- Updated the parent epic to declare `Primary tracker: #416` and moved `#326-#330` to a historical child issue mapping section. 
- Adjusted the PR draft metadata `last_updated` and wording to reflect linking to the live adoption tracker and retaining historical child drafts for traceability. 

### Testing

- Ran `npx markdownlint-cli2 ".github/projects/active/adoption-workstream-2026-05-26/**/*.md"` and it succeeded. 
- Ran `git diff --check` and it returned no trailing whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1700aaad848332b5ac126de84b702f)