### PR TITLE
docs: fix stale governance internal references

### DIFF
--- a/.github/custom-instructions.md
+++ b/.github/custom-instructions.md
@@ -121,6 +121,6 @@ scope. The target direction is:
 
 ## Related Project Documents
 
-- [Agent skill memory platform PRD](./projects/active/agent-skill-memory-platform/agent-skill-memory-platform-prd-2026-05-26.md)
-- [Agent skill memory platform inventory](./projects/active/agent-skill-memory-platform/agent-skill-memory-platform-inventory-2026-05-26.md)
-- [Agent skill memory platform parent issues](./projects/active/agent-skill-memory-platform/issues/parents/)
+- [Agent skill memory platform PRD](./projects/archived/agent-skill-memory-platform/agent-skill-memory-platform-prd-2026-05-26.md)
+- [Agent skill memory platform inventory](./projects/archived/agent-skill-memory-platform/agent-skill-memory-platform-inventory-2026-05-26.md)
+- [Agent skill memory platform parent issues](./projects/archived/agent-skill-memory-platform/issues/parents/)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ references:
 
 # 🏠 LightSpeed Community Health & Automation Repository
 
-[![Test Coverage](https://img.shields.io/badge/coverage-auto-blue)](./tests/TEST_COVERAGE_SUMMARY.md)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Test Coverage](https://img.shields.io/badge/coverage-auto-blue)](./tests/README.md)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](./LICENSE)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/lightspeedwp/.github/actions)
 [![Documentation](https://img.shields.io/badge/docs-comprehensive-informational)](./docs/README.md)
 [![AI Integration](https://img.shields.io/badge/AI-enhanced-purple)](./AGENTS.md)
@@ -561,14 +561,14 @@ The following are the default `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `ISSUE_TE
 - [issue-types.yml](./.github/issue-types.yml) – **Canonical issue types** for automation and triage.
 - [ISSUE_TYPES.md](https://github.com/lightspeedwp/.github/blob/HEAD/docs/ISSUE_TYPES.md) – Issue type documentation.
 - [Saved replies for issues](https://github.com/lightspeedwp/.github/blob/HEAD/.github/SAVED_REPLIES/README.md)
-- [Bug report saved reply](https://github.com/lightspeedwp/.github/blob/HEAD/.github/SAVED_REPLIES/bug-reports.md)
-- [Issue templates directory](https://github.com/lightspeedwp/.github/tree/develop/.github/ISSUE_TEMPLATES)
+- [Bug report saved reply](https://github.com/lightspeedwp/.github/blob/HEAD/.github/SAVED_REPLIES/issues/bug-reports.md)
+- [Issue templates directory](https://github.com/lightspeedwp/.github/tree/develop/.github/ISSUE_TEMPLATE)
 
 ### Pull Request Templates
 
-- [PR templates directory](https://github.com/lightspeedwp/.github/tree/develop/.github/PULL_REQUEST_TEMPLATES)
+- [PR templates directory](https://github.com/lightspeedwp/.github/tree/develop/.github/PULL_REQUEST_TEMPLATE)
 - [PR_LABELS.md](https://github.com/lightspeedwp/.github/blob/HEAD/docs/PR_LABELS.md)
-- [Pull Request Template (main)](./.github/PULL_REQUEST_TEMPLATE.md)
+- [Pull Request Template (main)](./.github/pull_request_template.md)
 
 ### Workflows & Automation
 
@@ -600,7 +600,7 @@ This repository will include and orchestrate org-wide agents for managing issue 
 
 - **Agents:** Configurations, prompts, and agent instructions live here.
 - **Integration:** All project boards and workflows reference canonical files here for automated syncing and status tracking.
-- **Governance:** [AUTOMATION_GOVERNANCE.md](https://github.com/lightspeedwp/.github/blob/develop/.github/AUTOMATION_GOVERNANCE.md) details how agents and workflows are managed, updated, and rolled out org-wide.
+- **Governance:** [AUTOMATION_GOVERNANCE.md](https://github.com/lightspeedwp/.github/blob/develop/docs/AUTOMATION_GOVERNANCE.md) details how agents and workflows are managed, updated, and rolled out org-wide.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ---
 title: "LightSpeed Community Health & Automation Repository"
 description: "Central hub for LightSpeed organization's community health files, automation standards, label management, governance documentation, and org-wide resources for GitHub usage and contribution."
-version: "2.0"
+version: "2.1"
 created_date: "2025-01-10"
-last_updated: "2026-05-18"
+last_updated: "2026-05-27"
 file_type: "documentation"
 maintainer: "LightSpeed Team"
 authors: ["LightSpeed Team"]
@@ -452,7 +452,7 @@ All code quality, formatting, and automation standards are documented and enforc
 
 - [LINTING.md](./docs/LINTING.md) — Main linting strategy, tool configuration, and automation
 - [HUSKY_PRECOMMITS.md](./docs/HUSKY_PRECOMMITS.md) — Pre-commit hook and automation details
-- [docs/config/](./docs/config/) — All configuration file documentation (ESLint, Prettier, Stylelint, Playwright, Jest, npm scripts, etc.)
+- [docs/CONFIGS.md](./docs/CONFIGS.md) — Configuration file documentation (ESLint, Prettier, Stylelint, Playwright, Jest, npm scripts, etc.)
 
 ### Local Linting & Formatting
 
@@ -522,8 +522,8 @@ flowchart LR
 
 ### Troubleshooting & Updates
 
-- For troubleshooting, see [docs/LINTING.md](./docs/LINTING.md) and [docs/config/](./docs/config/).
-- To update rules, edit the relevant config in `docs/config/` and update npm scripts as needed.
+- For troubleshooting, see [docs/LINTING.md](./docs/LINTING.md) and [docs/CONFIGS.md](./docs/CONFIGS.md).
+- To update rules, edit the relevant configuration file and update npm scripts as needed.
 
 ---
 
@@ -553,8 +553,8 @@ The following are the default `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `ISSUE_TE
 
 - [labels.yml](./.github/labels.yml) – **Canonical label definitions** for all issues and PRs.
 - [labeler.yml](./.github/labeler.yml) – Automated file/branch-based label application.
-- [ISSUE_LABELS.md](./.docs/ISSUE_LABELS.md) – Issue label documentation.
-- [PR_LABELS.md](./.docs/PR_LABELS.md) – PR label documentation.
+- [ISSUE_LABELS.md](./docs/ISSUE_LABELS.md) – Issue label documentation.
+- [PR_LABELS.md](./docs/PR_LABELS.md) – PR label documentation.
 
 ### Issue Types & Templates
 

--- a/docs/AUTOMATION_GOVERNANCE.md
+++ b/docs/AUTOMATION_GOVERNANCE.md
@@ -9,11 +9,11 @@
 
 All automation in this repository is implemented and governed according to the following standards:
 
-- **Instruction-First:** Each automation workflow is paired with a canonical instruction file in [../instructions/workflows.instructions.md](./instructions/workflows.instructions.md).
-- **Agent-Driven:** Each workflow is powered by a corresponding agent, documented in [../instructions/automation.instructions.md](./instructions/automation.instructions.md).
+- **Instruction-First:** Each automation workflow is paired with a canonical instruction file in [../instructions/workflows.instructions.md](../instructions/workflows.instructions.md).
+- **Agent-Driven:** Each workflow is powered by a corresponding agent, documented in [../instructions/automation.instructions.md](../instructions/automation.instructions.md).
 - **Dynamic Indexing:** Agents and workflows are discoverable and versioned via dynamic index files. These files are the single source of truth for automation and should be referenced for all changes or onboarding.
 - **Reciprocal Specification:** Every workflow must reference its agent; every agent must have a reciprocal specification file and reference its workflow(s).
-- **Evolving Standards:** All automation governance, standards, and best practices are maintained in the `.github/instructions/` folder and updated as the organization evolves.
+- **Evolving Standards:** All automation governance, standards, and best practices are maintained in the `instructions/` folder and updated as the organization evolves.
 
 ---
 
@@ -270,7 +270,7 @@ When `develop` merges to `main` (or on a release PR to main):
 6. **Docs Update:** Update stable tag, README badges, and other documentation as needed.
 7. **Notifications:** Notify maintainers/channels of release outcome.
 
-**Reciprocal Spec:** All release steps are defined in [workflows.instructions.md](./instructions/workflows.instructions.md) and [agent-release.instructions.md](./instructions/agent-release.instructions.md).
+**Reciprocal Spec:** All release steps are defined in [workflows.instructions.md](../instructions/workflows.instructions.md) and [release.agent.md](../agents/release.agent.md).
 
 ### 6.3 Labelling, Project Sync, and Issue/PR Management
 
@@ -286,7 +286,7 @@ When `develop` merges to `main` (or on a release PR to main):
 - On merge, auto-move item to Done and close linked issues.
 - Project meta sync logic is agent-driven and customizable.
 
-**Reciprocal Spec:** See [workflows.instructions.md](./instructions/workflows.instructions.md), [agent-labeling.instructions.md](./instructions/agents/agent-labeling.instructions.md), and [agent-project-meta-sync.instructions.md](./instructions/agent-project-meta-sync.instructions.md).
+**Reciprocal Spec:** See [workflows.instructions.md](../instructions/workflows.instructions.md), [labeling.agent.md](../agents/labeling.agent.md), and [project-meta-sync.agent.md](../agents/project-meta-sync.agent.md).
 
 ### 6.4 Branching Discipline
 
@@ -360,9 +360,9 @@ flowchart LR
 
 **Example configs:**
 
-- [labels-issues-prs.yml](./workflows/labels-issues-prs.yml)
-- [project-meta-sync.yml](./workflows/project-meta-sync.yml)
-- [labeler.yml](./labeler.yml)
+- [issues.yml](../.github/workflows/issues.yml)
+- [project-meta-sync.yml](../.github/workflows/project-meta-sync.yml)
+- [labeler.yml](../.github/labeler.yml)
 
 ---
 
@@ -377,7 +377,7 @@ flowchart LR
 
 ## 12. Maintaining and Auditing Automation
 
-- **Yearly Audit:** Annually, inventory all workflows and ensure every referenced agent has a reciprocal specification file in `.github/instructions/`.
+- **Yearly Audit:** Annually, inventory all workflows and ensure every referenced agent has a reciprocal specification in `agents/` and aligned guidance in `instructions/`.
 - **Change Process:** Any automation or agent update must update both its workflow and agent instruction/specification files.
 - **CI Enforcement:** (Recommended) Use a CI job or script to validate instruction/agent reciprocity and spec compliance.
 
@@ -394,8 +394,8 @@ flowchart LR
 
 ## Reference
 
-- [Workflows Instructions Index](./instructions/workflows.instructions.md)
-- [Automation Instructions](./instructions/automation.instructions.md)
+- [Workflows Instructions Index](../instructions/workflows.instructions.md)
+- [Automation Instructions](../instructions/automation.instructions.md)
 - [BRANCHING_STRATEGY.md](./BRANCHING_STRATEGY.md)
 - [CHANGELOG.md](../CHANGELOG.md)
 - [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/docs/AUTOMATION_GOVERNANCE.md
+++ b/docs/AUTOMATION_GOVERNANCE.md
@@ -220,7 +220,7 @@ Opt-outs: use `<!-- meta: off -->` (legacy `<!-- branding: off -->`) for body-le
 ### 6.1 Changelog Enforcement & Compilation
 
 - **Every PR must add an entry** under **Unreleased** in `CHANGELOG.md`, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
-- PR template must include a `## Changelog` section ([PR Template](https://github.com/lightspeedwp/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md)).
+- PR template must include a `## Changelog` section ([PR Template](https://github.com/lightspeedwp/.github/blob/main/.github/pull_request_template.md)).
 - **Automated Enforcement:** The release agent and related workflows enforce the presence and validity of changelog entries. PRs without valid changelogs will fail CI.
 
 **Changelog Format:**


### PR DESCRIPTION
## Summary
- fix stale internal reference paths identified in #424
- update archived project links in .github/custom-instructions.md
- correct README docs label-reference paths and configuration doc links
- repair automation governance references to current instruction, agent, workflow, and labeler paths

## Linked issue
Closes #424

## Validation
- node local relative-link existence check for in-scope files
- npx markdownlint-cli2 AGENTS.md .github/custom-instructions.md CONTRIBUTING.md README.md docs/AUTOMATION_GOVERNANCE.md
- git diff --check
- npm run validate:frontmatter:changed -- --base origin/develop --head HEAD
