### PR TITLE
docs(governance): add revision log process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 file_type: "documentation"
 title: "Contributing Guidelines"
 description: "Comprehensive contribution guidelines for LightSpeed community health repository including setup, standards, and workflow"
-version: "1.1"
+version: "1.2"
 last_updated: "2026-05-27"
 owners: ["LightSpeed Team"]
 tags: ["contributing", "guidelines", "workflow", "standards", "pull-requests"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,7 @@ Refer to `.vscode/extensions.json` and `.vscode/settings.json` for the authorita
 - **Saved Replies:** Use [SAVED_REPLIES/README.md](.github/SAVED_REPLIES/README.md) for common responses and efficient communication.
 - **Documentation:** Update relevant docs (README, instructions) for any user-facing change.
 - **Automation & Labels:** Ensure your issue/PR complies with [AUTOMATION_GOVERNANCE.md](./docs/AUTOMATION_GOVERNANCE.md), [ISSUE_LABELS.md](docs/ISSUE_LABELS.md), and [ISSUE_TYPES.md](./docs/ISSUE_TYPES.md).
+- **Governance process updates:** If your change modifies governance policy or contributor workflow expectations, add an entry to [GOVERNANCE_REVISION_LOG.md](./docs/GOVERNANCE_REVISION_LOG.md).
 - **Downstream overrides:** If you are adopting org defaults in another repository, follow [Downstream Override Policy](./docs/override-policy.md) and link any approved exception.
 - **Changelog:** All user-facing changes, fixes, and features must be entered in [CHANGELOG.md](./CHANGELOG.md) in Keep a Changelog format. See example sections in the changelog for proper grouping and linking.
 
@@ -140,6 +141,7 @@ Refer to `.vscode/extensions.json` and `.vscode/settings.json` for the authorita
 - [BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md): Org-wide branch naming, merge discipline, and automation mapping.
 - [CHANGELOG.md](./CHANGELOG.md): Changelog format, release notes, and versioning.
 - [AUTOMATION_GOVERNANCE.md](./docs/AUTOMATION_GOVERNANCE.md): Org-wide automation, branching, label, and release strategy.
+- [GOVERNANCE_REVISION_LOG.md](./docs/GOVERNANCE_REVISION_LOG.md): Lightweight audit trail for governance/process changes.
 - [override-policy.md](./docs/override-policy.md): Mandatory versus optional org defaults, exception handling, and promotion model.
 - [ISSUE_TYPES.md](./docs/ISSUE_TYPES.md): Issue type mapping and usage.
 - [ISSUE_LABELS.md](./docs/ISSUE_LABELS.md): Label families, triage, and workflow.

--- a/docs/AUTOMATION_GOVERNANCE.md
+++ b/docs/AUTOMATION_GOVERNANCE.md
@@ -389,6 +389,8 @@ flowchart LR
 - Link to it in project onboarding docs and contributor guides.
 - Treat as the single source of truth for automation, changelog, release, and labelling policies.
 - Update as automation or org-wide standards evolve; changes should be reviewed by maintainers.
+- Record governance/process updates in `docs/GOVERNANCE_REVISION_LOG.md` when
+  policy or workflow expectations change.
 
 ---
 
@@ -404,6 +406,7 @@ flowchart LR
 - [Issue Types YAML](../.github/issue-types.yml)
 - [Canonical Label Definitions](../.github/labels.yml)
 - [Automated Label Assignment Rules](../.github/labeler.yml)
+- [Governance Revision Log](./GOVERNANCE_REVISION_LOG.md)
 
 ---
 

--- a/docs/GOVERNANCE_REVISION_LOG.md
+++ b/docs/GOVERNANCE_REVISION_LOG.md
@@ -1,0 +1,60 @@
+---
+file_type: "documentation"
+title: "Governance Revision Log"
+description: "Lightweight change-tracking log for governance and process documentation updates."
+version: "1.0"
+last_updated: "2026-05-27"
+owners: ["LightSpeed Team"]
+tags: ["governance", "revision-log", "process", "documentation"]
+---
+
+# Governance Revision Log
+
+This log provides a lightweight audit trail for governance and process changes.
+Use it when policy or operating guidance changes and the rationale should be
+traceable over time.
+
+## Entry Format
+
+Each entry must include:
+
+- `date`: ISO date (`YYYY-MM-DD`)
+- `summary`: one-sentence description of what changed
+- `rationale`: why the change was needed
+- `links`: related issue and PR links
+
+Template:
+
+```markdown
+## YYYY-MM-DD
+
+- Summary: <what changed>
+- Rationale: <why it changed>
+- Links: #<issue>, #<pr>
+```
+
+## When An Entry Is Required
+
+Add an entry when a change modifies:
+
+- governance policy or process expectations;
+- contributor workflow requirements (triage, reviews, release, labelling);
+- canonical documentation paths or reference rules;
+- enforcement behaviour in governance-related automation.
+
+No entry is required for typo-only fixes that do not change meaning.
+
+## Ownership And Review Cadence
+
+- **Owner:** LightSpeed Team maintainers.
+- **Review cadence:** review unresolved or recent entries monthly; include this
+  check in quarterly governance audits.
+
+## Log Entries
+
+## 2026-05-27
+
+- Summary: Introduced the governance revision log process and standard entry
+  format.
+- Rationale: Governance updates needed a consistent, low-overhead audit trail.
+- Links: #423


### PR DESCRIPTION
## Summary
- add a lightweight governance revision log under docs/
- define minimal entry format (date, summary, rationale, links)
- document when entries are required and set owner/review cadence
- link revision log process from CONTRIBUTING and automation governance docs

## Linked issue
Closes #423

## Validation
- npx markdownlint-cli2 docs/GOVERNANCE_REVISION_LOG.md docs/AUTOMATION_GOVERNANCE.md CONTRIBUTING.md
- local relative-link existence check for changed files
- git diff --check
