### PR TITLE
docs(changelog): add v0.4.0 release section and preserve Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Expanded issue field governance to an organization-level v2 model aligned to
+  GitHub field capabilities (typed custom fields, hidden/system fields, and
+  iteration policy) with stricter validation.
+
+## [0.4.0] - 2026-05-27
+
+### Documentation
+
 - Added a canonical shared `.github` adoption guide with required, recommended,
   optional, and repo-local-only classifications, plus update and validation
   workflows for consuming repositories.
@@ -18,9 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added canonical issue-field governance documentation and automation, including
   `.github/issue-fields.yml`, `docs/ISSUE-FIELDS.md`, and workflow validation
   support for metadata consistency across issues and PRs.
-- Expanded issue field governance to an organization-level v2 model aligned to
-  GitHub field capabilities (typed custom fields, hidden/system fields, and
-  iteration policy) with stricter validation.
 
 ## [0.3.0] - 2025-12-18
 


### PR DESCRIPTION
## Summary\n- add dedicated `0.4.0` release section dated 2026-05-27\n- keep current pending work in `Unreleased`\n- retain changelog schema compliance\n\n## Validation\n- node scripts/validation/validate-changelog.cjs CHANGELOG.md\n