### PR TITLE
docs+chore: finalise adoption tracker links and coderaabbit config cleanup

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -282,23 +282,5 @@ reviews:
           - Confirm that documentation is up to date, accurate, and references related files or processes.
           - Ensure accessibility (e.g., heading hierarchy, alt text for images, no ambiguous language).
 
-early_access: true
-auto_labels:
-  enabled: true
-    - A canonical list of org wide default labels exists in this file "https://github.com/lightspeedwp/.github/blob/develop/.github/labels.yml" https://github.com/lightspeedwp/.github/blob/develop/.github/labeler.yml
-    - A set of labeler rules exist in this file "https://github.com/lightspeedwp/.github/blob/develop/.github/labeler.yml"
-auto_assign:
-  enabled: true
-  reviewers:
-    - "ashleyshaw"
-auto_review:
-  enabled: true
-  ignore_title_keywords:
-    - "WIP"
-    - "DO NOT MERGE"
-    - "DRAFT"
-  drafts: false
-  base_branches:
-    - "main"
-    - "develop"
-    - "feature/*"
+# Note: legacy `auto_labels`, `auto_assign`, and top-level `auto_review` keys
+# were removed because they are not recognised by the current CodeRabbit schema.

--- a/.github/projects/active/adoption-workstream-2026-05-26/README.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/README.md
@@ -1,8 +1,8 @@
 ---
 title: "Adoption Workstream Pack"
 description: "Execution pack for the next governance adoption workstream."
-version: "v0.1.0"
-last_updated: "2026-05-26"
+version: "v0.1.1"
+last_updated: "2026-05-27"
 file_type: "project"
 maintainer: "LightSpeed Team"
 authors: ["Codex"]
@@ -19,7 +19,11 @@ stability: "active"
 Execute the next governance adoption slice by consolidating reusable `.github`
 asset audit findings into a practical policy, usage guide, and decision record.
 
-## Linked live issues
+## Linked live issue
+
+- [#416](https://github.com/lightspeedwp/.github/issues/416)
+
+## Historical references (closed)
 
 - [#326](https://github.com/lightspeedwp/.github/issues/326)
 - [#327](https://github.com/lightspeedwp/.github/issues/327)

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/children/01-audit-reusable-assets-quality-gate.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/children/01-audit-reusable-assets-quality-gate.md
@@ -3,6 +3,8 @@ name: "Audit"
 title: "[Audit] Reusable .github assets quality gate"
 labels: [status:needs-audit, priority:important, type:documentation]
 github_issue: "https://github.com/lightspeedwp/.github/issues/326"
+tracker_issue: "https://github.com/lightspeedwp/.github/issues/416"
+legacy_issue: "https://github.com/lightspeedwp/.github/issues/326"
 ---
 
 ## Scope

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/children/02-define-adoption-policy.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/children/02-define-adoption-policy.md
@@ -3,6 +3,8 @@ name: "Documentation"
 title: "[Documentation] Define adoption policy"
 labels: [status:needs-triage, priority:important, area:documentation]
 github_issue: "https://github.com/lightspeedwp/.github/issues/327"
+tracker_issue: "https://github.com/lightspeedwp/.github/issues/416"
+legacy_issue: "https://github.com/lightspeedwp/.github/issues/327"
 ---
 
 ## Scope

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/children/03-write-adoption-guide.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/children/03-write-adoption-guide.md
@@ -3,6 +3,8 @@ name: "Documentation"
 title: "[Documentation] Write adoption guide"
 labels: [status:needs-triage, priority:important, area:documentation]
 github_issue: "https://github.com/lightspeedwp/.github/issues/328"
+tracker_issue: "https://github.com/lightspeedwp/.github/issues/416"
+legacy_issue: "https://github.com/lightspeedwp/.github/issues/328"
 ---
 
 ## Scope

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/children/04-assess-minimal-automation.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/children/04-assess-minimal-automation.md
@@ -3,6 +3,8 @@ name: "Audit"
 title: "[Audit] Assess minimal automation for adoption flow"
 labels: [status:needs-audit, priority:normal, type:automation]
 github_issue: "https://github.com/lightspeedwp/.github/issues/329"
+tracker_issue: "https://github.com/lightspeedwp/.github/issues/416"
+legacy_issue: "https://github.com/lightspeedwp/.github/issues/329"
 ---
 
 ## Scope

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/children/05-audit-maintenance-ownership-docs.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/children/05-audit-maintenance-ownership-docs.md
@@ -3,6 +3,8 @@ name: "Audit"
 title: "[Audit] Maintenance ownership documentation alignment"
 labels: [status:needs-audit, priority:important, area:documentation]
 github_issue: "https://github.com/lightspeedwp/.github/issues/330"
+tracker_issue: "https://github.com/lightspeedwp/.github/issues/416"
+legacy_issue: "https://github.com/lightspeedwp/.github/issues/330"
 ---
 
 ## Scope

--- a/.github/projects/active/adoption-workstream-2026-05-26/issues/parents/01-epic-adoption-governance-execution.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/issues/parents/01-epic-adoption-governance-execution.md
@@ -9,7 +9,9 @@ labels: [status:needs-triage, priority:important, type:epic, area:documentation]
 Track execution of the adoption governance slice using already-open issue
 threads and one delivery PR.
 
-## Child issue mapping
+Primary tracker: #416
+
+## Historical child issue mapping (closed)
 
 - #326 Audit reusable `.github` assets
 - #327 Define adoption policy

--- a/.github/projects/active/adoption-workstream-2026-05-26/pull-request-draft.md
+++ b/.github/projects/active/adoption-workstream-2026-05-26/pull-request-draft.md
@@ -1,21 +1,21 @@
 ---
 title: "PR Draft: Adoption governance workstream scaffold"
-last_updated: "2026-05-26"
+last_updated: "2026-05-27"
 ---
 
 ## Summary
 
 - Scaffolded the next workstream execution pack under
   `.github/projects/active/adoption-workstream-2026-05-26/`.
-- Mapped active adoption issues (`#326-#330`) into a structured parent/child
-  delivery pack.
+- Linked the pack to the live adoption tracker (`#416`) and marked
+  `#326-#330` as historical closed references.
 - Added ready-to-run scope, acceptance criteria, and rollout sequence.
 
 ## Files added
 
 - Workstream README and execution index
 - Parent epic draft
-- Five child issue drafts mapped to live issues
+- Five child issue drafts retained for historical traceability
 - This PR draft
 
 ## Validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded issue field governance to an organization-level v2 model aligned to
   GitHub field capabilities (typed custom fields, hidden/system fields, and
   iteration policy) with stricter validation.
+- Clarified adoption workstream tracker links and historical issue references
+  in the active adoption pack documentation.
 
 ## [0.4.0] - 2026-05-27
 


### PR DESCRIPTION
### Summary
- restore adoption child issue IDs and explicit tracker linkage in the adoption workstream pack
- keep historical closed references clear and aligned in the parent/PR draft docs
- remove unrecognised keys from `.coderabbit.yml`

### Supersedes
- #443
- #444

### Validation
- Changes are documentation/config only and merge cleanly onto current `develop`.
