### PR TITLE
fix(labeling): execute canonical label sync in workflow

### DIFF
--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -73,6 +73,9 @@ jobs:
         run: node scripts/validation/validate-issue-fields.cjs
 
       - name: Sync labels with canonical set
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event_name == 'pull_request' && 'true' || inputs.dry_run || 'false' }}
         run: |
           node scripts/agents/includes/label-sync.js
         shell: bash

--- a/docs/ISSUE_LABELS.md
+++ b/docs/ISSUE_LABELS.md
@@ -72,6 +72,9 @@ Colors are assigned by family and purpose; see `../.github/labels.yml` for mappi
 ## Automation
 
 - **Labeling, status, type, and standardization** are all handled by the **unified agent and workflow** ([labeling.agent.js](../scripts/agents/labeling.agent.js), [labeling.yml](../.github/workflows/labeling.yml)).
+- The label sync step (`scripts/agents/includes/label-sync.js`) now runs as an executable CLI in CI.
+  - On `pull_request` events it runs in dry-run mode.
+  - On other labeling workflow events it enforces canonical sync against `.github/labels.yml`.
 - **Default labels** are applied and enforced on all issues.
 - **Label conflicts and non-canonical labels** are removed or migrated automatically.
 

--- a/scripts/agents/includes/label-sync.js
+++ b/scripts/agents/includes/label-sync.js
@@ -508,6 +508,13 @@ async function runCli() {
   const markdown = generateSyncReport(syncReport, validationReport, null);
   process.stdout.write(`${markdown}\n`);
 
+  if (!validationReport.valid && dryRun) {
+    console.warn(
+      `[label-sync] Dry-run detected label drift (missing=${validationReport.summary.missingCount}, extra=${validationReport.summary.extraCount}, nonCompliant=${validationReport.summary.nonCompliantCount})`,
+    );
+    return;
+  }
+
   if (!validationReport.valid) {
     throw new Error(
       `Label validation failed (missing=${validationReport.summary.missingCount}, extra=${validationReport.summary.extraCount}, nonCompliant=${validationReport.summary.nonCompliantCount})`,

--- a/scripts/agents/includes/label-sync.js
+++ b/scripts/agents/includes/label-sync.js
@@ -13,6 +13,11 @@
 // TODO: Align this helper with the latest automation spec updates.
 
 import { findStandardLabel } from "./label-lookup.js";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+import github from "@actions/github";
 
 /**
  * Sync repository labels with canonical set.
@@ -435,3 +440,89 @@ export {
   standardizeLabelsOnRepo,
   generateSyncReport,
 };
+
+/**
+ * Load canonical label definitions from configured labels.yml file.
+ * @param {string} labelsPath - Path to labels.yml
+ * @returns {Promise<Array>} Canonical labels array
+ */
+async function loadCanonicalLabels(labelsPath) {
+  const raw = await fs.readFile(labelsPath, "utf8");
+  const parsed = yaml.load(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${labelsPath} must be an array of labels`);
+  }
+  return parsed;
+}
+
+/**
+ * Parse a string env value to boolean.
+ * @param {string|undefined} value - Env value
+ * @returns {boolean} Parsed boolean
+ */
+function asBoolean(value) {
+  if (!value) return false;
+  return ["1", "true", "yes", "on"].includes(String(value).toLowerCase());
+}
+
+/**
+ * CLI runner for repository label sync.
+ * Reads context from GitHub Actions env and syncs labels against canonical config.
+ * Exits non-zero when sync/validation fails.
+ */
+async function runCli() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error("GITHUB_TOKEN is required to run label sync");
+  }
+
+  const labelsPath = process.env.LABELS_CONFIG || ".github/labels.yml";
+  const dryRun = asBoolean(process.env.DRY_RUN);
+
+  const owner =
+    process.env.GITHUB_REPOSITORY_OWNER || github.context.repo.owner;
+  const repo =
+    process.env.GITHUB_REPOSITORY?.split("/")[1] || github.context.repo.repo;
+
+  if (!owner || !repo) {
+    throw new Error("Unable to resolve repository owner/name from environment");
+  }
+
+  const canonicalLabels = await loadCanonicalLabels(labelsPath);
+  const octokit = github.getOctokit(token);
+
+  const syncReport = await syncLabelsWithCanonical(
+    octokit,
+    owner,
+    repo,
+    canonicalLabels,
+    dryRun,
+  );
+  const validationReport = await validateRepoLabels(
+    octokit,
+    owner,
+    repo,
+    canonicalLabels,
+  );
+
+  const markdown = generateSyncReport(syncReport, validationReport, null);
+  process.stdout.write(`${markdown}\n`);
+
+  if (!validationReport.valid) {
+    throw new Error(
+      `Label validation failed (missing=${validationReport.summary.missingCount}, extra=${validationReport.summary.extraCount}, nonCompliant=${validationReport.summary.nonCompliantCount})`,
+    );
+  }
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  path.resolve(fileURLToPath(import.meta.url)) ===
+    path.resolve(process.argv[1]);
+
+if (isDirectRun) {
+  runCli().catch((error) => {
+    console.error(`[label-sync] ${error.message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- make `scripts/agents/includes/label-sync.js` executable when run directly in CI
- wire `GITHUB_TOKEN` and deterministic `DRY_RUN` behaviour into the labeling workflow sync step
- document sync behaviour in issue labels guide

## Why
Issue #66 requires canonical label and seeding workflow alignment. The workflow was invoking `node scripts/agents/includes/label-sync.js`, but that file had no CLI entrypoint, so sync was effectively a no-op.

## Changes
- Added a CLI runner to `label-sync.js` that:
  - reads canonical labels from `.github/labels.yml`
  - authenticates with `GITHUB_TOKEN`
  - performs canonical sync + validation
  - exits non-zero if validation fails
- Updated `.github/workflows/labeling.yml` sync step env:
  - `GITHUB_TOKEN` from workflow secret
  - `DRY_RUN=true` on `pull_request` events
  - non-PR events use workflow/input default (`false` when not provided)
- Updated `docs/ISSUE_LABELS.md` automation section for the new sync execution contract.

## Validation
- `node scripts/validation/validate-labeling-configs.cjs`
- `npx eslint scripts/agents/includes/label-sync.js`
- `npx markdownlint-cli2 docs/ISSUE_LABELS.md`
- `npx spectral lint .github/workflows/labeling.yml --ruleset .spectral-workflows.cjs`

## Links
- Parent epic: #449
- Task: #66
