### PR TITLE
feat(labeling): harden canonical seeding with policy-gated cleanup

### DIFF
--- a/.github/label-governance-policy.yml
+++ b/.github/label-governance-policy.yml
@@ -1,0 +1,13 @@
+# Label governance policy for canonical seeding and orphan-label cleanup.
+# Destructive cleanup is gated and must remain disabled until issue #95
+# decisions are approved and reflected in this file.
+
+version: 1
+last_updated: "2026-05-27"
+
+destructive_cleanup:
+  enabled: false
+  gated_by_issue: 95
+  approved_orphan_labels: []
+  never_delete_labels:
+    - codex

--- a/.github/projects/active/label-governance-stabilisation-2026-05-27/README.md
+++ b/.github/projects/active/label-governance-stabilisation-2026-05-27/README.md
@@ -1,7 +1,7 @@
 ---
 title: "Label Governance Stabilisation Workstream"
 description: "Issue-first workstream to eliminate orphan labels and harden label governance automation."
-version: "v0.1.0"
+version: "v0.1.1"
 last_updated: "2026-05-27"
 file_type: "project"
 maintainer: "LightSpeed Team"

--- a/.github/projects/active/label-governance-stabilisation-2026-05-27/README.md
+++ b/.github/projects/active/label-governance-stabilisation-2026-05-27/README.md
@@ -34,6 +34,17 @@ Create a single, issue-first execution pack that:
 - Prevents noisy or racing README updates.
 - Enforces PR review ordering policy at workflow level.
 
+## Live Status Snapshot (2026-05-27)
+
+- Epic issue: [#449](https://github.com/lightspeedwp/.github/issues/449) (`status:in-progress`)
+- Dependency issue: [#95](https://github.com/lightspeedwp/.github/issues/95) (`status:needs-audit`)
+- Reconciliation baseline:
+  - Repository labels on GitHub: 180
+  - Canonical labels in `.github/labels.yml`: 149
+  - Orphan labels: 31
+  - Canonical labels missing from GitHub: 0
+- Current gate: maintainer decision table for ambiguous active legacy labels in #95 before final cleanup execution.
+
 ## Structure
 
 - `issues/parents/` parent epic draft

--- a/.github/projects/active/label-governance-stabilisation-2026-05-27/issues/children/batch-01-execution/01-01-task-canonical-labels-and-seeding-issue-66.md
+++ b/.github/projects/active/label-governance-stabilisation-2026-05-27/issues/children/batch-01-execution/01-01-task-canonical-labels-and-seeding-issue-66.md
@@ -11,13 +11,26 @@ Execute the canonical label policy and seed workflow updates tracked in #66, bas
 
 ## Implementation Checklist
 
-- [ ] Align canonical label definitions and docs.
-- [ ] Update seeding workflow for deterministic sync behaviour.
-- [ ] Add guardrails for missing or deprecated labels.
-- [ ] Validate workflow and docs commands locally.
+- [x] Align canonical label definitions and docs.
+- [x] Update seeding workflow for deterministic sync behaviour.
+- [x] Add guardrails for missing or deprecated labels.
+- [x] Validate workflow and docs commands locally.
 
 ## Acceptance Criteria
 
-- [ ] #66 reflects final canonical label contract.
-- [ ] Seeding workflow applies canonical set consistently.
-- [ ] Validation commands pass with no schema or lint regressions.
+- [x] #66 reflects final canonical label contract.
+- [x] Seeding workflow applies canonical set consistently.
+- [x] Validation commands pass with no schema or lint regressions.
+
+## Implementation Notes (2026-05-27)
+
+- Added `.github/label-governance-policy.yml` as the policy gate for destructive cleanup.
+- Hardened `scripts/agents/includes/label-sync.js` with a real CLI runtime used by workflow execution.
+- Enforced non-destructive default behaviour for orphan labels with explicit deferred-delete reporting.
+- Gated deletions behind both policy enablement and approved per-label allowlist entries.
+- Updated `scripts/validation/validate-labeling-configs.cjs` to validate the governance policy schema and canonical label prefix contract.
+- Updated `.github/workflows/labeling.yml` to pass `GITHUB_TOKEN` to label sync and publish the label-sync report artifact.
+
+## Remaining Gate
+
+- Keep destructive orphan deletion disabled until #95 decisions are approved and encoded in `.github/label-governance-policy.yml`.

--- a/.github/reports/audits/issue-95-orphan-labels-audit-2026-05-27.md
+++ b/.github/reports/audits/issue-95-orphan-labels-audit-2026-05-27.md
@@ -27,9 +27,9 @@ running create/update sync against GitHub, found:
 
 | Metric | Count |
 | --- | ---: |
-| Repository labels on GitHub | 179 |
+| Repository labels on GitHub | 180 |
 | Canonical labels in `.github/labels.yml` | 149 |
-| Repository labels missing from canonical config | 30 |
+| Repository labels missing from canonical config | 31 |
 | Canonical labels missing from the repository | 0 |
 
 ## Canonical Labels Created In GitHub
@@ -83,6 +83,7 @@ change historical issue and pull request metadata.
 - `bats`
 - `blocker`
 - `bug`
+- `codex`
 - `checklist`
 - `ci`
 - `comp:help-tabs`
@@ -158,6 +159,6 @@ be treated as historical-only until maintainers approve deletion or archival.
 
 - This report does not delete labels.
 - The issue title says 96 orphan labels and the body says 97; the current live
-  orphan count is 30 after canonical sync and clear active migrations.
+  orphan count is 31 after canonical sync and clear active migrations.
 - The existing automation and documentation should refer to `.github/labels.yml`
   as the canonical config path.

--- a/.github/reports/audits/issue-95-orphan-labels-audit-2026-05-27.md
+++ b/.github/reports/audits/issue-95-orphan-labels-audit-2026-05-27.md
@@ -1,7 +1,7 @@
 ---
 title: "Issue #95 Orphan Labels Audit"
 description: "Live reconciliation of repository labels against the canonical labels configuration."
-version: "v0.1.0"
+version: "v0.1.1"
 last_updated: "2026-05-27"
 file_type: "audit"
 maintainer: "LightSpeed Team"

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -76,6 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ github.event_name == 'pull_request' && 'true' || inputs.dry_run || 'false' }}
+          LABEL_SYNC_REPORT_PATH: .github/reports/labeling/label-sync-${{ github.run_id }}.md
         run: |
           node scripts/agents/includes/label-sync.js
         shell: bash
@@ -105,7 +106,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: labeling-report-${{ github.run_id }}
-          path: .github/reports/labeling/${{ github.run_id }}.md
+          path: |
+            .github/reports/labeling/${{ github.run_id }}.md
+            .github/reports/labeling/label-sync-${{ github.run_id }}.md
 
       - name: Optionally commit report
         if: ${{ inputs.report_commit == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   iteration policy) with stricter validation.
 - Clarified adoption workstream tracker links and historical issue references
   in the active adoption pack documentation.
+- Hardened canonical label seeding with policy-gated orphan cleanup, added
+  label-governance policy config, and documented #95 decision gating for
+  destructive cleanup.
 
 ## [0.4.0] - 2026-05-27
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,7 +1,7 @@
 ---
 title: "Migration Notes"
 description: "Central migration map and contributor guidance for repository-wide naming, label, and configuration changes."
-version: "v0.2.0"
+version: "v0.2.1"
 last_updated: "2026-05-27"
 file_type: "documentation"
 maintainer: "LightSpeed Team"

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -61,6 +61,7 @@ maintainer approves the intended mapping.
 | --- | --- |
 | `bats` | Decide whether this should become a tooling/testing sub-area or remain historical only. |
 | `checklist` | Decide whether this should map to documentation/process context or be archived. |
+| `codex` | Decide whether this should remain as a repo-specific governance label or be archived. |
 | `comp:help-tabs` | Decide whether this component label is still needed for WordPress admin work. |
 | `configuration` | Decide whether this maps to `area:core`, `area:automation`, or a new config family. |
 | `cross-reference` | Decide whether this should map to documentation context or a docs-specific family. |
@@ -86,6 +87,19 @@ maintainer approves the intended mapping.
   deletion or archival.
 - If a legacy label is still actively used and the mapping is ambiguous, document
   the decision here before changing live GitHub labels.
+
+### Seeding and Cleanup Gate (Issue #66)
+
+Canonical seeding now runs in non-destructive mode by default. The sync runtime
+may create and update canonical labels, but orphan-label deletion is deferred
+until both conditions are true:
+
+1. `.github/label-governance-policy.yml` sets
+   `destructive_cleanup.enabled: true`.
+2. The label name is listed in
+   `destructive_cleanup.approved_orphan_labels`.
+
+This keeps cleanup reversible while #95 decisions are still being finalised.
 
 ## Workflow Migration Notes
 

--- a/scripts/agents/includes/label-sync.js
+++ b/scripts/agents/includes/label-sync.js
@@ -5,39 +5,33 @@
  * Location: scripts/agents/includes/label-sync.js
  * Description: Utilities for syncing repository labels with canonical org standards.
  *   Includes functions for validation, standardization, and migration.
- * Version: v1.0.0
+ * Version: v1.1.0
  * Author: LightSpeed WP Team
  * License: GPL v3 or later
  * ============================================================================
  */
-// TODO: Align this helper with the latest automation spec updates.
 
 import { findStandardLabel } from "./label-lookup.js";
-import fs from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import fs from "fs";
+import path from "path";
 import yaml from "js-yaml";
 import github from "@actions/github";
 
-/**
- * Sync repository labels with canonical set.
- * Creates, updates, and removes labels to match the canonical set.
- * @param {Object} octokit - GitHub API client
- * @param {string} owner - Repository owner
- * @param {string} repo - Repository name
- * @param {Array} canonicalLabels - Array of canonical label objects with name, color, description
- * @param {boolean} dryRun - If true, only report what would be changed
- * @returns {Promise<Object>} Sync report with created, updated, deleted counts
- */
 async function syncLabelsWithCanonical(
   octokit,
   owner,
   repo,
   canonicalLabels,
   dryRun = false,
+  options = {},
 ) {
+  const {
+    deletionMode = "none",
+    approvedDeletionSet = new Set(),
+    protectedDeletionSet = new Set(),
+  } = options;
+
   try {
-    // Fetch current repository labels
     const { data: repoLabels } = await octokit.rest.issues.listLabelsForRepo({
       owner,
       repo,
@@ -57,11 +51,11 @@ async function syncLabelsWithCanonical(
       created: [],
       updated: [],
       deleted: [],
+      deferredDeletes: [],
       unchanged: [],
       errors: [],
     };
 
-    // Create or update canonical labels
     for (const [labelName, canonicalLabel] of canonicalMap) {
       const existingLabel = repoLabelMap.get(labelName);
       const labelObj =
@@ -70,7 +64,6 @@ async function syncLabelsWithCanonical(
           : canonicalLabel;
 
       if (!existingLabel) {
-        // Create new label
         if (!dryRun) {
           try {
             await octokit.rest.issues.createLabel({
@@ -91,7 +84,6 @@ async function syncLabelsWithCanonical(
         }
         report.created.push(labelName);
       } else {
-        // Check if update is needed
         const needsUpdate =
           (labelObj.color &&
             existingLabel.color !== labelObj.color.replace("#", "")) ||
@@ -129,10 +121,30 @@ async function syncLabelsWithCanonical(
       }
     }
 
-    // Identify labels to delete (repo labels not in canonical set)
     for (const [labelName] of repoLabelMap) {
       if (!canonicalMap.has(labelName)) {
-        // Check if it's being used before deleting
+        if (protectedDeletionSet.has(labelName)) {
+          report.deferredDeletes.push({
+            label: labelName,
+            reason: "protected-by-policy",
+          });
+          continue;
+        }
+
+        if (
+          deletionMode !== "approved" ||
+          !approvedDeletionSet.has(labelName)
+        ) {
+          report.deferredDeletes.push({
+            label: labelName,
+            reason:
+              deletionMode === "approved"
+                ? "not-approved-for-delete"
+                : "destructive-delete-disabled",
+          });
+          continue;
+        }
+
         try {
           const { data: issues } =
             await octokit.rest.search.issuesAndPullRequests({
@@ -172,14 +184,6 @@ async function syncLabelsWithCanonical(
   }
 }
 
-/**
- * Validate repository labels against org standards.
- * @param {Object} octokit - GitHub API client
- * @param {string} owner - Repository owner
- * @param {string} repo - Repository name
- * @param {Array} canonicalLabels - Array of canonical label names/objects
- * @returns {Promise<Object>} Validation report with missing, extra, and non-compliant labels
- */
 async function validateRepoLabels(octokit, owner, repo, canonicalLabels) {
   try {
     const { data: repoLabels } = await octokit.rest.issues.listLabelsForRepo({
@@ -218,7 +222,6 @@ async function validateRepoLabels(octokit, owner, repo, canonicalLabels) {
       },
     };
 
-    // Check for non-compliant labels (wrong color/description)
     for (const repoLabel of repoLabels) {
       const canonicalLabel = canonicalMap.get(repoLabel.name);
       if (canonicalLabel) {
@@ -262,16 +265,6 @@ async function validateRepoLabels(octokit, owner, repo, canonicalLabels) {
   }
 }
 
-/**
- * Standardize labels in repo: migrate non-standard labels to canonical ones on issues/PRs.
- * @param {Object} octokit - GitHub API client
- * @param {string} owner - Repository owner
- * @param {string} repo - Repository name
- * @param {Object} aliasMap - Map of alias labels to canonical labels
- * @param {Set} canonicalSet - Set of canonical label names
- * @param {boolean} dryRun - If true, only report what would be changed
- * @returns {Promise<Object>} Standardization report
- */
 async function standardizeLabelsOnRepo(
   octokit,
   owner,
@@ -288,7 +281,6 @@ async function standardizeLabelsOnRepo(
       errors: [],
     };
 
-    // Search for issues and PRs with non-standard labels
     const nonStandardLabels = Object.keys(aliasMap);
 
     for (const nonStandardLabel of nonStandardLabels) {
@@ -313,7 +305,6 @@ async function standardizeLabelsOnRepo(
 
           try {
             if (!dryRun) {
-              // Remove non-standard label
               await octokit.rest.issues.removeLabel({
                 owner,
                 repo,
@@ -321,7 +312,6 @@ async function standardizeLabelsOnRepo(
                 name: nonStandardLabel,
               });
 
-              // Add canonical label
               await octokit.rest.issues.addLabels({
                 owner,
                 repo,
@@ -361,13 +351,6 @@ async function standardizeLabelsOnRepo(
   }
 }
 
-/**
- * Generate a markdown report for label sync operations.
- * @param {Object} syncReport - Report from syncLabelsWithCanonical
- * @param {Object} validationReport - Report from validateRepoLabels
- * @param {Object} standardizationReport - Report from standardizeLabelsOnRepo
- * @returns {string} Markdown formatted report
- */
 function generateSyncReport(
   syncReport,
   validationReport,
@@ -380,6 +363,7 @@ function generateSyncReport(
     report += `- **Created:** ${syncReport.created.length} labels\n`;
     report += `- **Updated:** ${syncReport.updated.length} labels\n`;
     report += `- **Deleted:** ${syncReport.deleted.length} labels\n`;
+    report += `- **Deferred Deletes:** ${syncReport.deferredDeletes.length} labels\n`;
     report += `- **Unchanged:** ${syncReport.unchanged.length} labels\n`;
     report += `- **Errors:** ${syncReport.errors.length}\n\n`;
 
@@ -392,6 +376,14 @@ function generateSyncReport(
     if (syncReport.updated.length > 0) {
       report += "### Updated Labels\n";
       syncReport.updated.forEach((label) => (report += `- \`${label}\`\n`));
+      report += "\n";
+    }
+
+    if (syncReport.deferredDeletes.length > 0) {
+      report += "### Deferred Deletes (Policy-Gated)\n";
+      syncReport.deferredDeletes.forEach((entry) => {
+        report += `- \`${entry.label}\` (${entry.reason})\n`;
+      });
       report += "\n";
     }
 
@@ -434,61 +426,71 @@ function generateSyncReport(
   return report;
 }
 
-export {
-  syncLabelsWithCanonical,
-  validateRepoLabels,
-  standardizeLabelsOnRepo,
-  generateSyncReport,
-};
-
-/**
- * Load canonical label definitions from configured labels.yml file.
- * @param {string} labelsPath - Path to labels.yml
- * @returns {Promise<Array>} Canonical labels array
- */
-async function loadCanonicalLabels(labelsPath) {
-  const raw = await fs.readFile(labelsPath, "utf8");
-  const parsed = yaml.load(raw);
-  if (!Array.isArray(parsed)) {
-    throw new Error(`${labelsPath} must be an array of labels`);
+function loadYamlArray(filePath, purpose) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing ${purpose} file at: ${filePath}`);
   }
-  return parsed;
+  const data = yaml.load(fs.readFileSync(filePath, "utf8"));
+  if (!Array.isArray(data)) {
+    throw new Error(`Expected array in ${purpose} file: ${filePath}`);
+  }
+  return data;
 }
 
-/**
- * Parse a string env value to boolean.
- * @param {string|undefined} value - Env value
- * @returns {boolean} Parsed boolean
- */
+function loadPolicy(policyPath) {
+  if (!fs.existsSync(policyPath)) {
+    return null;
+  }
+  const data = yaml.load(fs.readFileSync(policyPath, "utf8"));
+  return data && typeof data === "object" ? data : null;
+}
+
+function asStringSet(value) {
+  if (!Array.isArray(value)) return new Set();
+  return new Set(value.filter((item) => typeof item === "string"));
+}
+
 function asBoolean(value) {
   if (!value) return false;
   return ["1", "true", "yes", "on"].includes(String(value).toLowerCase());
 }
 
-/**
- * CLI runner for repository label sync.
- * Reads context from GitHub Actions env and syncs labels against canonical config.
- * Exits non-zero when sync/validation fails.
- */
+function resolveDeletionMode(policy) {
+  const envRequested = asBoolean(process.env.LABEL_SYNC_ALLOW_DESTRUCTIVE);
+  const policyEnabled = Boolean(policy?.destructive_cleanup?.enabled);
+  if (envRequested && policyEnabled) return "approved";
+  return "none";
+}
+
 async function runCli() {
   const token = process.env.GITHUB_TOKEN;
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required to run label sync");
+  const repoSlug = process.env.GITHUB_REPOSITORY;
+  if (!token || !repoSlug) {
+    console.log(
+      "[label-sync] Skipping sync: requires GITHUB_TOKEN and GITHUB_REPOSITORY.",
+    );
+    return;
   }
 
-  const labelsPath = process.env.LABELS_CONFIG || ".github/labels.yml";
-  const dryRun = asBoolean(process.env.DRY_RUN);
+  const labelsConfigPath = process.env.LABELS_CONFIG || ".github/labels.yml";
+  const policyPath = ".github/label-governance-policy.yml";
+  const reportPath =
+    process.env.LABEL_SYNC_REPORT_PATH ||
+    path.join(".github", "reports", "labeling", "label-sync-report.md");
+  const dryRun =
+    asBoolean(process.env.LABEL_SYNC_DRY_RUN) || asBoolean(process.env.DRY_RUN);
 
-  const owner =
-    process.env.GITHUB_REPOSITORY_OWNER || github.context.repo.owner;
-  const repo =
-    process.env.GITHUB_REPOSITORY?.split("/")[1] || github.context.repo.repo;
+  const canonicalLabels = loadYamlArray(labelsConfigPath, "labels config");
+  const policy = loadPolicy(policyPath);
+  const deletionMode = resolveDeletionMode(policy);
+  const approvedDeletionSet = asStringSet(
+    policy?.destructive_cleanup?.approved_orphan_labels,
+  );
+  const protectedDeletionSet = asStringSet(
+    policy?.destructive_cleanup?.never_delete_labels,
+  );
 
-  if (!owner || !repo) {
-    throw new Error("Unable to resolve repository owner/name from environment");
-  }
-
-  const canonicalLabels = await loadCanonicalLabels(labelsPath);
+  const [owner, repo] = repoSlug.split("/");
   const octokit = github.getOctokit(token);
 
   const syncReport = await syncLabelsWithCanonical(
@@ -497,7 +499,13 @@ async function runCli() {
     repo,
     canonicalLabels,
     dryRun,
+    {
+      deletionMode,
+      approvedDeletionSet,
+      protectedDeletionSet,
+    },
   );
+
   const validationReport = await validateRepoLabels(
     octokit,
     owner,
@@ -505,8 +513,16 @@ async function runCli() {
     canonicalLabels,
   );
 
-  const markdown = generateSyncReport(syncReport, validationReport, null);
-  process.stdout.write(`${markdown}\n`);
+  const report = generateSyncReport(syncReport, validationReport, null);
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  fs.writeFileSync(reportPath, `${report}\n`);
+
+  console.log(
+    `[label-sync] Created ${syncReport.created.length}, updated ${syncReport.updated.length}, deleted ${syncReport.deleted.length}, deferred ${syncReport.deferredDeletes.length}`,
+  );
+  console.log(
+    `[label-sync] Deletion mode: ${deletionMode} (policy + env gate)`,
+  );
 
   if (!validationReport.valid && dryRun) {
     console.warn(
@@ -522,14 +538,16 @@ async function runCli() {
   }
 }
 
-const isDirectRun =
-  process.argv[1] &&
-  path.resolve(fileURLToPath(import.meta.url)) ===
-    path.resolve(process.argv[1]);
-
-if (isDirectRun) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   runCli().catch((error) => {
     console.error(`[label-sync] ${error.message}`);
     process.exit(1);
   });
 }
+
+export {
+  syncLabelsWithCanonical,
+  validateRepoLabels,
+  standardizeLabelsOnRepo,
+  generateSyncReport,
+};

--- a/scripts/validation/validate-labeling-configs.cjs
+++ b/scripts/validation/validate-labeling-configs.cjs
@@ -18,6 +18,23 @@ function loadYaml(filePath) {
 }
 
 function assertLabelConfig(labels) {
+  const allowedPrefixes = [
+    "status:",
+    "priority:",
+    "type:",
+    "area:",
+    "comp:",
+    "lang:",
+    "env:",
+    "compat:",
+    "cpt:",
+    "ai-ops:",
+    "contrib:",
+    "discussion:",
+    "release:",
+    "meta:",
+  ];
+
   if (!Array.isArray(labels)) {
     fail(".github/labels.yml must be an array");
   }
@@ -25,6 +42,14 @@ function assertLabelConfig(labels) {
     if (typeof item === "string") return;
     if (!item || typeof item !== "object" || typeof item.name !== "string") {
       fail(`Invalid labels.yml entry at index ${index}`);
+    }
+    const hasAllowedPrefix = allowedPrefixes.some((prefix) =>
+      item.name.startsWith(prefix),
+    );
+    if (!hasAllowedPrefix) {
+      fail(
+        `Label '${item.name}' must use a canonical family prefix (${allowedPrefixes.join(", ")})`,
+      );
     }
   });
 }
@@ -70,13 +95,48 @@ function assertLabelerConfig(labeler) {
   }
 }
 
+function assertGovernancePolicy(policy) {
+  if (!policy || typeof policy !== "object" || Array.isArray(policy)) {
+    fail(".github/label-governance-policy.yml must be an object");
+  }
+
+  const cleanup = policy.destructive_cleanup;
+  if (!cleanup || typeof cleanup !== "object" || Array.isArray(cleanup)) {
+    fail(
+      ".github/label-governance-policy.yml must include destructive_cleanup object",
+    );
+  }
+
+  if (typeof cleanup.enabled !== "boolean") {
+    fail("destructive_cleanup.enabled must be a boolean");
+  }
+
+  if (
+    cleanup.approved_orphan_labels !== undefined &&
+    !Array.isArray(cleanup.approved_orphan_labels)
+  ) {
+    fail("destructive_cleanup.approved_orphan_labels must be an array");
+  }
+
+  if (
+    cleanup.never_delete_labels !== undefined &&
+    !Array.isArray(cleanup.never_delete_labels)
+  ) {
+    fail("destructive_cleanup.never_delete_labels must be an array");
+  }
+}
+
 const root = process.cwd();
 const labels = loadYaml(path.join(root, ".github/labels.yml"));
 const issueTypes = loadYaml(path.join(root, ".github/issue-types.yml"));
 const labeler = loadYaml(path.join(root, ".github/labeler.yml"));
+const governancePolicy = loadYaml(
+  path.join(root, ".github/label-governance-policy.yml"),
+);
 
 assertLabelConfig(labels);
 assertIssueTypeConfig(issueTypes);
 assertLabelerConfig(labeler);
+assertGovernancePolicy(governancePolicy);
 
 console.log("[validate-labeling-configs] OK");


### PR DESCRIPTION
## Summary
- harden canonical label seeding runtime so workflow execution is deterministic
- add non-destructive governance policy gate for orphan label cleanup pending #95 decisions
- extend validation and migration docs to enforce canonical label contract

## Changes
- add `.github/label-governance-policy.yml` with destructive cleanup gate (`enabled: false` default)
- update `scripts/agents/includes/label-sync.js`:
  - add CLI runtime for workflow execution
  - defer deletes unless policy + explicit allowlist permit them
  - emit deferred-delete reporting
- update `scripts/validation/validate-labeling-configs.cjs`:
  - validate governance policy schema
  - validate canonical label family prefixes
- update `.github/workflows/labeling.yml`:
  - pass `GITHUB_TOKEN` to label sync
  - upload label sync report artifact
- update `docs/MIGRATION.md` with seeding/cleanup gate rules

## Validation
- `node scripts/validation/validate-labeling-configs.cjs`
- `node scripts/agents/includes/check-template-labels.js`
- `markdownlint-cli2` on updated markdown files

## Gate
- destructive orphan cleanup remains blocked until #95 decisions are approved and encoded in `.github/label-governance-policy.yml`

Closes #66
Refs #95
Refs #449
