### PR TITLE
feat(workflows): scope README regen and enforce reviewer ordering

### DIFF
--- a/.github/label-governance-policy.yml
+++ b/.github/label-governance-policy.yml
@@ -10,4 +10,34 @@ destructive_cleanup:
   gated_by_issue: 95
   approved_orphan_labels: []
   never_delete_labels:
+    - a11y
+    - audit
+    - automation
+    - bats
+    - blocker
+    - bug
+    - checklist
+    - ci
+    - comp:help-tabs
+    - configuration
     - codex
+    - cross-reference
+    - css
+    - dependencies
+    - documentation
+    - github_actions
+    - governance
+    - javascript
+    - js
+    - lang:javascript
+    - maintenance
+    - meta
+    - meta:duplicate
+    - onboarding
+    - package.json
+    - path-resolution
+    - php
+    - quickstart
+    - security
+    - standards
+    - test

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -145,6 +145,8 @@ jobs:
           node-version: "20"
 
       - name: Run Meta Agent
+        env:
+          META_SKIP_README: "true"
         run: |
           node scripts/agents/meta.agent.js
 

--- a/.github/workflows/readme-regen.yml
+++ b/.github/workflows/readme-regen.yml
@@ -1,0 +1,110 @@
+name: readme-regen
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+    paths:
+      - "**/*.md"
+      - ".github/workflows/**"
+      - ".github/agents/**"
+      - ".github/instructions/**"
+      - "docs/**"
+      - "scripts/**"
+  push:
+    branches: [develop]
+    paths:
+      - "**/*.md"
+      - ".github/workflows/**"
+      - ".github/agents/**"
+      - ".github/instructions/**"
+      - "docs/**"
+      - "scripts/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: readme-regen-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  readme-regen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve impacted README files
+        id: readmes
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+          else
+            BASE_SHA="HEAD~1"
+            HEAD_SHA="${{ github.sha }}"
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          if [ -z "$CHANGED" ]; then
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TMP=$(mktemp)
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            dir=$(dirname "$file")
+            if [ -f "$dir/README.md" ]; then
+              echo "$dir/README.md" >> "$TMP"
+            fi
+            if [ "$dir" != "." ] && [ -f "README.md" ]; then
+              echo "README.md" >> "$TMP"
+            fi
+          done <<EOF
+          $CHANGED
+          EOF
+
+          FILES=$(sort -u "$TMP" | tr '\n' ',' | sed 's/,$//')
+          rm -f "$TMP"
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+
+      - name: Run README regeneration
+        if: steps.readmes.outputs.files != ''
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            node scripts/agents/meta.agent.js --dry-run --files "${{ steps.readmes.outputs.files }}"
+          else
+            node scripts/agents/meta.agent.js --files "${{ steps.readmes.outputs.files }}"
+          fi
+
+      - name: Commit README updates
+        if: github.event_name != 'pull_request' && steps.readmes.outputs.files != ''
+        run: |
+          git config user.name "lightspeed-bot"
+          git config user.email "ops@lightspeedwp.agency"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(readme): regenerate impacted README files [skip ci]"
+            git push origin ${{ github.ref_name }}
+          fi

--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -8,10 +8,53 @@ on:
 
 permissions:
   contents: read
+  statuses: read
   pull-requests: write
 
+concurrency:
+  group: reviewer-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  coderabbit-gate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require CodeRabbit success before reviewer
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.payload.pull_request.head.sha;
+            const maxAttempts = 20;
+            const delayMs = 15000;
+
+            for (let i = 1; i <= maxAttempts; i++) {
+              const { data } = await github.rest.repos.getCombinedStatusForRef({
+                owner,
+                repo,
+                ref: sha,
+              });
+              const coderabbit = (data.statuses || []).find((s) => s.context === "CodeRabbit");
+              if (coderabbit && coderabbit.state === "success") {
+                core.info(`CodeRabbit is successful on attempt ${i}.`);
+                return;
+              }
+              if (coderabbit && coderabbit.state === "failure") {
+                core.setFailed("CodeRabbit failed; reviewer job is blocked until fixed.");
+                return;
+              }
+              core.info(`Waiting for CodeRabbit success (${i}/${maxAttempts})...`);
+              await new Promise((resolve) => setTimeout(resolve, delayMs));
+            }
+
+            core.setFailed("Timed out waiting for CodeRabbit success; reviewer job blocked.");
+
   reviewer:
+    needs: [coderabbit-gate]
+    if: always() && (github.event_name != 'pull_request' || needs.coderabbit-gate.result == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/ISSUE_LABELS.md
+++ b/docs/ISSUE_LABELS.md
@@ -75,6 +75,9 @@ Colors are assigned by family and purpose; see `../.github/labels.yml` for mappi
 - The label sync step (`scripts/agents/includes/label-sync.js`) now runs as an executable CLI in CI.
   - On `pull_request` events it runs in dry-run mode.
   - On other labeling workflow events it enforces canonical sync against `.github/labels.yml`.
+- Orphan-label cleanup policy is controlled in [`.github/label-governance-policy.yml`](../.github/label-governance-policy.yml):
+  - `destructive_cleanup.enabled` gates destructive label deletion.
+  - `never_delete_labels` documents accepted repository-specific exceptions.
 - **Default labels** are applied and enforced on all issues.
 - **Label conflicts and non-canonical labels** are removed or migrated automatically.
 

--- a/scripts/agents/includes/label-sync.js
+++ b/scripts/agents/includes/label-sync.js
@@ -184,7 +184,13 @@ async function syncLabelsWithCanonical(
   }
 }
 
-async function validateRepoLabels(octokit, owner, repo, canonicalLabels) {
+async function validateRepoLabels(
+  octokit,
+  owner,
+  repo,
+  canonicalLabels,
+  allowedExtraSet = new Set(),
+) {
   try {
     const { data: repoLabels } = await octokit.rest.issues.listLabelsForRepo({
       owner,
@@ -211,13 +217,19 @@ async function validateRepoLabels(octokit, owner, repo, canonicalLabels) {
       missing: Array.from(canonicalSet).filter(
         (name) => !repoLabelSet.has(name),
       ),
-      extra: repoLabelNames.filter((name) => !canonicalSet.has(name)),
+      extra: repoLabelNames.filter(
+        (name) => !canonicalSet.has(name) && !allowedExtraSet.has(name),
+      ),
+      allowedExtra: repoLabelNames.filter(
+        (name) => !canonicalSet.has(name) && allowedExtraSet.has(name),
+      ),
       nonCompliant: [],
       summary: {
         totalCanonical: canonicalSet.size,
         totalRepo: repoLabels.length,
         missingCount: 0,
         extraCount: 0,
+        allowedExtraCount: 0,
         nonCompliantCount: 0,
       },
     };
@@ -253,6 +265,7 @@ async function validateRepoLabels(octokit, owner, repo, canonicalLabels) {
 
     report.summary.missingCount = report.missing.length;
     report.summary.extraCount = report.extra.length;
+    report.summary.allowedExtraCount = report.allowedExtra.length;
     report.summary.nonCompliantCount = report.nonCompliant.length;
     report.valid =
       report.missing.length === 0 &&
@@ -403,6 +416,7 @@ function generateSyncReport(
     report += `- **Total Repository:** ${validationReport.summary.totalRepo}\n`;
     report += `- **Missing:** ${validationReport.summary.missingCount}\n`;
     report += `- **Extra:** ${validationReport.summary.extraCount}\n`;
+    report += `- **Allowed extra:** ${validationReport.summary.allowedExtraCount}\n`;
     report += `- **Non-compliant:** ${validationReport.summary.nonCompliantCount}\n\n`;
   }
 
@@ -511,6 +525,7 @@ async function runCli() {
     owner,
     repo,
     canonicalLabels,
+    protectedDeletionSet,
   );
 
   const report = generateSyncReport(syncReport, validationReport, null);

--- a/scripts/agents/meta.agent.js
+++ b/scripts/agents/meta.agent.js
@@ -61,6 +61,12 @@ const emojiSchema = loadEmojiSchema();
  */
 function shouldSkipMeta(filePath, content) {
   const fileName = path.basename(filePath);
+  const skipReadme =
+    String(process.env.META_SKIP_README || "").toLowerCase() === "true";
+
+  if (skipReadme && fileName === "README.md") {
+    return true;
+  }
 
   // Skip formal documents
   const formalDocs = ["CHANGELOG.md", "CODE_OF_CONDUCT.md"];
@@ -477,12 +483,15 @@ async function processMarkdownFile(filePath, options = {}) {
  * @returns {Promise<object>} A summary object of the results.
  */
 async function processAllMarkdownFiles(options = {}) {
-  const { pattern = "**/*.md" } = options;
+  const { pattern = "**/*.md", files: explicitFiles } = options;
 
-  const files = globSync(pattern, {
-    cwd: process.cwd(),
-    ignore: ["node_modules/**", ".git/**", "**/node_modules/**"],
-  });
+  const files =
+    Array.isArray(explicitFiles) && explicitFiles.length > 0
+      ? explicitFiles
+      : globSync(pattern, {
+          cwd: process.cwd(),
+          ignore: ["node_modules/**", ".git/**", "**/node_modules/**"],
+        });
 
   const results = {
     total: files.length,
@@ -521,12 +530,24 @@ async function main() {
   const verbose =
     process.argv.includes("--verbose") || process.argv.includes("-v");
   const dryRun = process.argv.includes("--dry-run");
+  const filesArgIndex = process.argv.findIndex((arg) => arg === "--files");
+  const fileList =
+    filesArgIndex > -1 && process.argv[filesArgIndex + 1]
+      ? process.argv[filesArgIndex + 1]
+          .split(",")
+          .map((f) => f.trim())
+          .filter(Boolean)
+      : [];
 
   console.log("Meta Agent - Starting...");
   console.log(`Mode: ${dryRun ? "DRY RUN" : "LIVE"}`);
   console.log("");
 
-  const results = await processAllMarkdownFiles({ verbose, dryRun });
+  const results = await processAllMarkdownFiles({
+    verbose,
+    dryRun,
+    files: fileList,
+  });
 
   console.log("\nMeta Agent - Summary:");
   console.log(`  Total files: ${results.total}`);


### PR DESCRIPTION
## Summary
- implement scoped README regeneration workflow with changed-path targeting and concurrency guard (`#67`)
- enforce CodeRabbit-success gate before reviewer job execution (`#69`)
- codify orphan-label exception policy and treat protected labels as allowed extras in label validation (`#95`)

## Changes
### `#67` README regeneration scope/concurrency
- added `.github/workflows/readme-regen.yml`
  - scoped triggers for markdown/workflow/agent/instruction changes
  - computes impacted README paths from git diff
  - processes only impacted README files via `meta.agent --files`
  - uses workflow concurrency guard: `readme-regen-${{ github.ref }}`
- updated `.github/workflows/meta.yml`
  - set `META_SKIP_README=true` for meta-agent run to avoid duplicate/conflicting README writes
- updated `scripts/agents/meta.agent.js`
  - added `--files` support for targeted processing
  - added `META_SKIP_README` handling

### `#69` CodeRabbit-before-reviewer enforcement
- updated `.github/workflows/reviewer.yml`
  - added `coderabbit-gate` job that waits for `CodeRabbit` status context success on PR head SHA
  - blocks reviewer execution on CodeRabbit failure/timeout
  - reviewer now depends on gate result for PR events
  - added workflow concurrency control

### `#95` orphan-label policy disposition
- updated `.github/label-governance-policy.yml`
  - documented accepted repository-specific orphan-label exception set under `never_delete_labels`
- updated `scripts/agents/includes/label-sync.js`
  - validation now treats policy-protected labels as allowed extras
  - report now includes `Allowed extra` count
- updated `docs/ISSUE_LABELS.md`
  - documented policy controls for destructive cleanup and accepted exceptions

## Validation
- `npx eslint scripts/agents/meta.agent.js scripts/agents/includes/label-sync.js`
- `npx markdownlint-cli2 docs/ISSUE_LABELS.md`
- `npx spectral lint .github/workflows/reviewer.yml .github/workflows/readme-regen.yml .github/workflows/meta.yml --ruleset .spectral-workflows.cjs`
- `node scripts/validation/validate-labeling-configs.cjs`
- `node scripts/validation/validate-workflows.js`

## Links
- Epic: #449
- Issues: #95, #67, #69
