### PR TITLE
test: validate workflow/agent imports/includes with smoke tests (#63)

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,9 @@
     "test": "npm run test:js",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",
-    "contributors:check": "all-contributors check"
+    "contributors:check": "all-contributors check",
+    "test:bash": "bats tests/bash/*.bats",
+    "test:imports": "jest --config .jest.config.cjs tests/js/import-includes-smoke.test.js --runInBand"
   },
   "devDependencies": {
     "@actions/core": "1.11.1",

--- a/tests/bash/strict-mode.bats
+++ b/tests/bash/strict-mode.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+collect_shell_files() {
+  find scripts .github -type f \( -name '*.sh' -o -name '*.bash' \) | sort
+}
+
+@test "first-party shell scripts use strict mode" {
+  shell_files="$(collect_shell_files)"
+
+  if [ -z "$shell_files" ]; then
+    skip "No first-party shell scripts found under scripts/ or .github/."
+  fi
+
+  missing=""
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    if ! grep -Eq '^set -Eeuo pipefail$' "$file"; then
+      missing="$missing$file\n"
+    fi
+  done <<EOF_FILES
+$shell_files
+EOF_FILES
+
+  if [ -n "$missing" ]; then
+    printf 'Missing strict mode in:\n%b' "$missing" >&2
+    return 1
+  fi
+}

--- a/tests/js/import-includes-smoke.test.js
+++ b/tests/js/import-includes-smoke.test.js
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const filesToValidate = [
+  "scripts/agents/includes/check-template-labels.js",
+  "scripts/agents/includes/label-sync.js",
+  "scripts/agents/includes/build-labeling-report.js",
+  "scripts/agents/includes/fetch-canonical-labels.js",
+  "scripts/agents/includes/label-utils.js",
+  "scripts/agents/includes/type-lookup.js",
+  "scripts/agents/includes/yaml-parser.js",
+  "scripts/agents/includes/yaml-validator.js",
+  "scripts/agents/labeling.agent.js",
+  "scripts/agents/project-meta-sync.agent.js",
+];
+
+const importRegex = /import\s+(?:[^'";]+\s+from\s+)?['"]([^'"]+)['"]/g;
+const requireRegex = /require\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+function localImportTargets(source) {
+  const matches = [];
+  for (const regex of [importRegex, requireRegex]) {
+    regex.lastIndex = 0;
+    let match;
+    while ((match = regex.exec(source)) !== null) {
+      const target = match[1];
+      if (target.startsWith("./") || target.startsWith("../")) {
+        matches.push(target);
+      }
+    }
+  }
+  return matches;
+}
+
+function resolveCandidate(baseDir, target) {
+  const raw = path.resolve(baseDir, target);
+  const candidates = [
+    raw,
+    `${raw}.js`,
+    `${raw}.cjs`,
+    `${raw}.mjs`,
+    path.join(raw, "index.js"),
+  ];
+
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+describe("workflow and agent JS import/include smoke validation", () => {
+  test.each(filesToValidate)(
+    "validates local imports/includes in %s",
+    (filePath) => {
+      const absolutePath = path.resolve(process.cwd(), filePath);
+      const source = fs.readFileSync(absolutePath, "utf8");
+      const baseDir = path.dirname(absolutePath);
+
+      const missing = localImportTargets(source)
+        .map((target) => ({
+          target,
+          resolved: resolveCandidate(baseDir, target),
+        }))
+        .filter(({ resolved }) => !resolved)
+        .map(({ target }) => target);
+
+      expect(missing).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- adds `tests/js/import-includes-smoke.test.js` to validate local import/include resolution for critical workflow and agent entry points
- adds `tests/bash/strict-mode.bats` to enforce `set -Eeuo pipefail` on first-party shell scripts under `scripts/` and `.github/`
- adds npm scripts `test:imports` and `test:bash` for local and CI execution

## Validation
- `npm run test:imports`
- `npm run test:bash`

## Issue
- Closes #63
