### PR TITLE
docs(ai): consolidate canonical ai/* sources (#64)

### DIFF
--- a/.github/custom-instructions.md
+++ b/.github/custom-instructions.md
@@ -37,6 +37,8 @@ Use these files as the primary map before editing:
 | File | Purpose |
 | --- | --- |
 | [`../AGENTS.md`](../AGENTS.md) | Global AI rules, tone, security, accessibility, and contribution expectations. |
+| [`../ai/agents.md`](../ai/agents.md) | Canonical AI source-of-truth map for agent docs and model references. |
+| [`../ai/RUNNERS.md`](../ai/RUNNERS.md) | Canonical JS/Bash runner and telemetry inventory. |
 | [`.github/instructions/file-organisation.instructions.md`](./instructions/file-organisation.instructions.md) | Repo-local placement rules for GitHub-native files versus portable AI assets. |
 | [`../instructions/coding-standards.instructions.md`](../instructions/coding-standards.instructions.md) | Coding standards and WordPress-oriented engineering expectations. |
 | [`../instructions/documentation-formats.instructions.md`](../instructions/documentation-formats.instructions.md) | Markdown, frontmatter, and Mermaid standards. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@ tags: ["agents", "ai", "coding-standards", "governance", "wordpress"]
 domain: "governance"
 stability: "stable"
 references:
+  - path: "ai/agents.md"
+    description: "Canonical AI agents source-of-truth index"
+  - path: "ai/RUNNERS.md"
+    description: "Canonical runner and telemetry inventory"
   - path: "agents/agent.md"
     description: "Main agent implementations index"
   - path: ".github/custom-instructions.md"
@@ -36,6 +40,7 @@ references:
 
 ## Agent Directory
 
+- Canonical AI source map: [ai/agents.md](ai/agents.md)
 - See [Main Agent Index](agents/agent.md) for all agent implementations and specs.
 - Each agent must have both a code file (`.js`, `.py`, etc.) and a spec (`.md`) following the template.
 - All contributors must follow the org [Coding Standards](instructions/coding-standards.instructions.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 ---
 title: "LightSpeed Global AI Rules"
 description: "Organisation-wide AI agent rules, coding standards, and contribution guidelines for all LightSpeed WordPress projects."
-version: "v1.3"
-last_updated: "2026-05-27"
+version: "v1.4"
+last_updated: "2026-05-28"
 file_type: "agents-index"
 maintainer: "LightSpeed Team"
 authors: ["LightSpeed Team"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,6 @@ npm run validate:frontmatter
 
 - [AGENTS.md](./AGENTS.md) — full global AI rules
 - [.github/custom-instructions.md](./.github/custom-instructions.md) — Copilot-specific repo instructions
-- [.github/instructions/coding-standards.instructions.md](./.github/instructions/coding-standards.instructions.md) — unified coding standards
+- [instructions/coding-standards.instructions.md](./instructions/coding-standards.instructions.md) — unified coding standards
 - [.github/instructions/file-organisation.instructions.md](./.github/instructions/file-organisation.instructions.md) — canonical file placement rules
 - [.github/instructions/plugin-structure.instructions.md](./.github/instructions/plugin-structure.instructions.md) — WordPress block plugin structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 ---
 title: "LightSpeed .github — Claude Instructions"
 description: "Claude-specific project instructions for the LightSpeed .github repository."
-version: "v1.0"
-last_updated: "2026-05-20"
+version: "v1.1"
+last_updated: "2026-05-28"
 file_type: "agents-index"
 maintainer: "LightSpeed Team"
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ maintainer: "LightSpeed Team"
 
 > Full organisation-wide AI rules, coding standards, and contribution guidelines live in [AGENTS.md](./AGENTS.md). Read that file first.
 
+Canonical AI references are maintained under [`ai/`](./ai/), including
+[`ai/Claude.md`](./ai/Claude.md), [`ai/Gemini.md`](./ai/Gemini.md), and
+[`ai/RUNNERS.md`](./ai/RUNNERS.md).
+
 ## What This Repository Is
 
 This is the **LightSpeed organisation `.github` control plane**. It owns:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ For comprehensive documentation, see the [docs/](./docs/) folder and [.github/RE
 
 ### 🤖 AI & Automation
 
+- [ai/agents.md](./ai/agents.md) - Canonical AI agent sources and policy map
+- [ai/Claude.md](./ai/Claude.md) - Canonical Claude reference
+- [ai/Gemini.md](./ai/Gemini.md) - Canonical Gemini reference
+- [ai/RUNNERS.md](./ai/RUNNERS.md) - Runner inventory and telemetry hooks
 - [AGENTS.md](./AGENTS.md) - Global AI rules and agent overview
 - [.github/custom-instructions.md](./.github/custom-instructions.md) - Copilot configuration
 - [agents/agent.md](agents/agent.md) - Agent specifications

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ---
 title: "LightSpeed Community Health & Automation Repository"
 description: "Central hub for LightSpeed organization's community health files, automation standards, label management, governance documentation, and org-wide resources for GitHub usage and contribution."
-version: "2.1"
+version: "2.2"
 created_date: "2025-01-10"
-last_updated: "2026-05-27"
+last_updated: "2026-05-28"
 file_type: "documentation"
 maintainer: "LightSpeed Team"
 authors: ["LightSpeed Team"]

--- a/ai/Claude.md
+++ b/ai/Claude.md
@@ -1,0 +1,31 @@
+---
+title: "Claude Canonical Reference"
+description: "Authoritative Claude-specific guidance and pointers for LightSpeed repositories."
+version: "v1.0.0"
+last_updated: "2026-05-28"
+file_type: "documentation"
+maintainer: "LightSpeed Team"
+authors: ["LightSpeed Team"]
+license: "GPL-3.0"
+tags: ["ai", "claude", "agents", "governance"]
+domain: "governance"
+stability: "stable"
+---
+
+# Claude Canonical Reference
+
+This document is the canonical Claude-specific entry point.
+
+## Core References
+
+- [CLAUDE.md](../CLAUDE.md) - runtime and repo boundary instructions for Claude.
+- [AGENTS.md](../AGENTS.md) - non-negotiable global AI rules.
+- [Custom instructions](../.github/custom-instructions.md) - repo-local
+  operating constraints.
+
+## Usage Notes
+
+- Treat `CLAUDE.md` as the direct Claude runtime contract.
+- Apply `AGENTS.md` defaults for standards, safety, accessibility, and
+  maintainability.
+- Follow `.github` boundary rules before moving or creating reusable assets.

--- a/ai/Gemini.md
+++ b/ai/Gemini.md
@@ -1,0 +1,32 @@
+---
+title: "Gemini Canonical Reference"
+description: "Authoritative Gemini-specific guidance and pointers for LightSpeed repositories."
+version: "v1.0.0"
+last_updated: "2026-05-28"
+file_type: "documentation"
+maintainer: "LightSpeed Team"
+authors: ["LightSpeed Team"]
+license: "GPL-3.0"
+tags: ["ai", "gemini", "agents", "governance"]
+domain: "governance"
+stability: "stable"
+---
+
+# Gemini Canonical Reference
+
+This document is the canonical Gemini-specific entry point.
+
+## Core References
+
+- [AGENTS.md](../AGENTS.md) - global AI rules and contribution standards.
+- [Custom instructions](../.github/custom-instructions.md) - repo-local
+  operating constraints.
+- [Model recommendation prompt](../.github/prompts/model-recommendation.prompt.md)
+  - legacy reference for model selection and migration notes.
+
+## Usage Notes
+
+- Follow `AGENTS.md` as the baseline for all Gemini-authored changes.
+- Keep repo-native governance changes in `.github/` and reusable assets in top
+  level portable folders.
+- Treat prompt-library model notes as secondary guidance, not canonical policy.

--- a/ai/RUNNERS.md
+++ b/ai/RUNNERS.md
@@ -1,0 +1,49 @@
+---
+title: "AI Runner Inventory"
+description: "Canonical inventory of JavaScript and Bash runners plus telemetry hooks used in this repository."
+version: "v1.0.0"
+last_updated: "2026-05-28"
+file_type: "documentation"
+maintainer: "LightSpeed Team"
+authors: ["LightSpeed Team"]
+license: "GPL-3.0"
+tags: ["ai", "runners", "javascript", "bash", "telemetry"]
+domain: "governance"
+stability: "active"
+---
+
+# AI Runner Inventory
+
+This file documents runner entry points currently used by repository automation.
+
+## JavaScript Runners
+
+- `scripts/agents/*.agent.js` - primary operational agent runners.
+- `scripts/workflows/release/*.cjs` - workflow runtime wrappers for release and
+  telemetry logic.
+- `scripts/validation/*.js|*.cjs` - validation runners used in CI and local
+  quality gates.
+
+## Bash Runners
+
+- GitHub workflow inline shell remains present in selected workflows during
+  phased migration.
+- Local shell hooks under `.husky/` (`pre-commit`, `pre-push`) orchestrate
+  Node-based checks.
+- Portable shell helpers under `skills/**/scripts/*.sh` remain out of scope for
+  phase-1 workflow migration.
+
+## Telemetry Hooks
+
+- `.github/workflows/release.yml` trigger telemetry is emitted via
+  `scripts/workflows/release/trigger-telemetry.cjs` and uploaded as
+  `trigger-telemetry.json` artifact.
+- Workflow-level health and metrics updates are recorded through existing
+  metrics automation and reporting workflows in `.github/workflows/`.
+
+## Migration Direction
+
+- Default new runner logic to Node CLI scripts.
+- Avoid introducing new Bash-heavy control-flow in workflows.
+- Keep legacy shell runner inventory explicit until phase-2 migration is
+  complete.

--- a/ai/agents.md
+++ b/ai/agents.md
@@ -1,0 +1,40 @@
+---
+title: "AI Agents Canonical Reference"
+description: "Authoritative index for LightSpeed AI agent governance and implementation sources."
+version: "v1.0.0"
+last_updated: "2026-05-28"
+file_type: "documentation"
+maintainer: "LightSpeed Team"
+authors: ["LightSpeed Team"]
+license: "GPL-3.0"
+tags: ["ai", "agents", "governance", "automation"]
+domain: "governance"
+stability: "stable"
+---
+
+# AI Agents Canonical Reference
+
+This file is the canonical AI agents index for the LightSpeed `.github` control
+plane.
+
+## Primary Sources
+
+- [AGENTS.md](../AGENTS.md) - organisation-wide AI rules and coding standards.
+- [Main agent index](../agents/agent.md) - portable agent specs.
+- [Repo-local custom instructions](../.github/custom-instructions.md) -
+  maintenance boundaries for this repository.
+
+## Agent Source-of-Truth Policy
+
+- Global governance and behaviour rules belong in `AGENTS.md`.
+- Reusable agent specs belong in `agents/`.
+- Repo-local operational instructions belong in `.github/instructions/` and
+  `.github/custom-instructions.md`.
+- Legacy `.github/agents/` content is transitional and should not become the
+  long-term canonical source for reusable specs.
+
+## Related Canonical AI Docs
+
+- [Claude](./Claude.md)
+- [Gemini](./Gemini.md)
+- [Runners](./RUNNERS.md)


### PR DESCRIPTION
Adds canonical ai/agents.md, ai/Claude.md, ai/Gemini.md, and ai/RUNNERS.md; rewires README/AGENTS/CLAUDE/custom-instructions to point at ai/* authority docs. Closes #64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metadata versions and timestamps across reference documents
  * Added new canonical AI agent governance and runner documentation files
  * Established consolidated index for AI agent sources and implementation references
  * Expanded AI & Automation documentation links in project README and related guides
  * Updated custom instructions with references to canonical agent and runner inventories

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeedwp/.github/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->