### PR TITLE
docs: convert spec-only agents into tracked issue set (#61)

### DIFF
--- a/.github/projects/active/spec-only-agents-issue-conversion-2026-05-28.md
+++ b/.github/projects/active/spec-only-agents-issue-conversion-2026-05-28.md
@@ -1,0 +1,64 @@
+---
+title: "Spec-only Agents Issue Conversion"
+description: "Execution record for converting spec-only agents into tracked issues with template-aligned structure and project sync labels."
+version: "v1.0.0"
+last_updated: "2026-05-28"
+file_type: "project"
+maintainer: "LightSpeed Team"
+authors: ["Codex"]
+license: "GPL-3.0"
+tags: ["agents", "issues", "project-mapping", "automation"]
+domain: "governance"
+stability: "active"
+---
+
+## Scope
+
+Implements issue `#61` by converting spec-only agents into tracked GitHub issues
+using the active task template structure and project-sync labels.
+
+## Canonical Created Issues
+
+- `agents/adr.agent.md` -> #464
+- `agents/issues.agent.md` -> #465
+- `agents/labeling.agent.md` -> #466
+- `agents/linting.agent.md` -> #467
+- `agents/meta.agent.md` -> #468
+- `agents/metrics.agent.md` -> #469
+- `agents/mode-demonstrate-understanding.agent.md` -> #470
+- `agents/mode-document-reviewer.agent.md` -> #471
+- `agents/mode-prd.agent.md` -> #473
+- `agents/mode-thinking.agent.md` -> #475
+- `agents/project-meta-sync.agent.md` -> #476
+- `agents/prompt-engineer.agent.md` -> #478
+- `agents/release.agent.md` -> #480
+- `agents/reporting.agent.md` -> #482
+- `agents/reviewer.agent.md` -> #474
+- `agents/task-planner.agent.md` -> #484
+- `agents/task-researcher.agent.md` -> #486
+- `agents/template.agent.md` -> #488
+- `agents/testing.agent.md` -> #490
+
+## Label and Field Mapping Strategy
+
+All created issues were labeled with:
+
+- `status:needs-triage`
+- `priority:normal`
+- `type:task`
+- `area:automation`
+
+These labels are used by existing repo automation to sync issues into the org
+project and populate status and type fields.
+
+## Duplicate Cleanup
+
+During bulk creation, transient GitHub indexing lag created duplicate titles for
+some agents. Duplicates were closed immediately and linked back to canonical
+issues.
+
+## Completion Notes
+
+- Parent tracker: #61
+- Next step after this conversion set: triage and execution sequencing across
+  #464-#490 in the project board.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Added spec-only agent issue conversion tracking under `#61`, including
+  canonical issue mapping and duplicate cleanup notes.
 - Added Husky pre-push contributor guidance and aligned local development docs
   with enforced pre-push test hooks (`npm run test:js`, `npm run test:bash`).
 - Expanded issue field governance to an organization-level v2 model aligned to

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 title: "LightSpeed Community Health & Automation Repository"
 description: "Central hub for LightSpeed organization's community health files, automation standards, label management, governance documentation, and org-wide resources for GitHub usage and contribution."
-version: "2.2"
+version: "2.3"
 created_date: "2025-01-10"
 last_updated: "2026-05-28"
 file_type: "documentation"


### PR DESCRIPTION
## Summary\n- add a conversion record for spec-only agent issue tracking\n- document canonical issue IDs and dedupe handling\n- capture label strategy used for project-field sync\n\n## Validation\n- markdownlint-cli2 v0.19.0 (markdownlint v0.39.0)
Finding: projects/active/spec-only-agents-issue-conversion-2026-05-28.md
Linting: 1 file(s)
Summary: 0 error(s)\n\nCloses #61