### PR TITLE
docs(60): finalise telemetry pilot closeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `docs/downstream/tour-operator-adoption.md` with pilot telemetry
   baseline checklist, target metrics, documented opt-out points, metrics
   emission example, and dashboard-consumption stub for `#60`.
+- Finalised `#60` documentation closeout with patch bump to
+  `docs/downstream/tour-operator-adoption.md` (`v0.1.1`) and explicit pilot
+  closeout status links.
 - Added spec-only agent issue conversion tracking under `#61`, including
   canonical issue mapping and duplicate cleanup notes.
 - Added Husky pre-push contributor guidance and aligned local development docs

--- a/docs/downstream/tour-operator-adoption.md
+++ b/docs/downstream/tour-operator-adoption.md
@@ -2,7 +2,7 @@
 file_type: "documentation"
 title: "Tour Operator Pilot Telemetry And Opt-Out Adoption Guide"
 description: "Baseline checklist, telemetry metrics, opt-out points, and dashboard stub for Tour Operator pilot adoption."
-version: "v0.1.0"
+version: "v0.1.1"
 last_updated: "2026-05-28"
 author: "LightSpeed Team"
 maintainer: "LightSpeed Team"
@@ -112,3 +112,9 @@ export function aggregateTourOperatorMetrics(events) {
 - [Metrics Policy](../METRICS.md)
 - [Release Process](../RELEASE_PROCESS.md)
 - [Automation Governance](../AUTOMATION_GOVERNANCE.md)
+
+## Pilot Closeout Status
+
+- Issue tracking: [#60](https://github.com/lightspeedwp/.github/issues/60)
+- Initial implementation merged into `develop` via commit `1c63a26`.
+- This document is the canonical pilot reference for telemetry and opt-outs.


### PR DESCRIPTION
## Summary\n- finalise Tour Operator telemetry pilot doc with closeout status\n- bump doc frontmatter version to patch ()\n- update changelog for #60 closeout tracking\n\n## Links\n- Closes #60\n\n## Validation\n- markdownlint on changed docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tour operator adoption documentation with pilot closeout status information.
  * Added canonical reference details for telemetry and opt-out procedures.
  * Documentation version bumped to v0.1.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeedwp/.github/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->