### PR TITLE
feat: automate canonical issue field sync and governance docs

### DIFF
--- a/.github/custom-instructions.md
+++ b/.github/custom-instructions.md
@@ -99,10 +99,13 @@ scope. The target direction is:
 1. Read the relevant issue draft or GitHub issue before editing.
 2. Check file placement with
    [`file-organisation.instructions.md`](./instructions/file-organisation.instructions.md).
-3. Keep changes scoped to the issue; do not move production assets in policy
+3. Maximise metadata completeness for issue and PR operations:
+   apply all applicable labels, type, milestone, project fields, assignees,
+   project assignment, and relationship links (parent-child, blocking, related).
+4. Keep changes scoped to the issue; do not move production assets in policy
    update tasks.
-4. Run targeted validation that does not mutate unrelated files.
-5. Use `git status --short` before finishing and call out unrelated changes.
+5. Run targeted validation that does not mutate unrelated files.
+6. Use `git status --short` before finishing and call out unrelated changes.
 
 ## Validation Notes
 

--- a/.github/issue-fields.yml
+++ b/.github/issue-fields.yml
@@ -67,6 +67,75 @@ project_field_mappings:
     type:review: Task
 
 organization_issue_fields:
+  universal_issue_fields:
+    applies_to_issue_types:
+      - Unassigned
+      - Task
+      - Bug
+      - Feature
+      - Code Refactor
+      - Build & CI
+      - A11y
+      - Compatibility
+      - Security
+      - Release
+      - Maintenance
+      - Performance
+      - Test Coverage
+      - Epic
+      - Automation
+      - Code Review
+      - Design
+      - Story
+      - Improvement
+      - Documentation
+      - Integration
+      - Research
+      - Chore
+      - Audit
+      - AI Ops
+      - Content Modelling
+  field_usage:
+    Priority:
+      type: single_select
+      values:
+        - Urgent
+        - High
+        - Medium
+        - Low
+      required: false
+      applies_to_all_issue_types: true
+      notes:
+        - Current importance level assigned to this issue.
+    Start date:
+      type: date
+      required: false
+      applies_to_all_issue_types: true
+      organization_only: true
+      notes:
+        - Date when work on issue will begin.
+    Target date:
+      type: date
+      required: false
+      applies_to_all_issue_types: true
+      organization_only: true
+      notes:
+        - Expected completion date for this issue.
+    Effort:
+      type: single_select
+      values:
+        - XS
+        - S
+        - M
+        - L
+        - XL
+        - XXL
+        - XXXL
+      required: false
+      applies_to_all_issue_types: true
+      organization_only: true
+      notes:
+        - Relative sizing estimate for implementation effort.
   enabled_issue_types:
     - Bug
     - Feature
@@ -126,9 +195,17 @@ organization_issue_fields:
         - QA
       default: AI Ops
     - key: Effort
-      type: number
-      description: Relative effort estimate in points.
-      default: 3
+      type: single_select
+      description: Relative sizing estimate for implementation effort.
+      options:
+        - XS
+        - S
+        - M
+        - L
+        - XL
+        - XXL
+        - XXXL
+      default: M
     - key: Start date
       type: date
       description: Planned start date.

--- a/.github/workflows/project-meta-sync.yml
+++ b/.github/workflows/project-meta-sync.yml
@@ -117,6 +117,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           PR_MERGED: ${{ github.event.pull_request.merged }}
+          ITEM_CREATED_AT: ${{ github.event.issue.created_at || github.event.pull_request.created_at }}
           ISSUE_FIELDS_CONFIG: .github/issue-fields.yml
 
       - name: Update project fields
@@ -126,8 +127,8 @@ jobs:
           project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ steps.app-token.outputs.token }}
           item-id: ${{ steps.addp.outputs.itemId }}
-          field-keys: Status,Priority,Type
-          field-values: ${{ steps.derive.outputs.status }},${{ steps.derive.outputs.priority }},${{ steps.derive.outputs.type }}
+          field-keys: Status,Priority,Type,Effort,Start date
+          field-values: ${{ steps.derive.outputs.status }},${{ steps.derive.outputs.priority }},${{ steps.derive.outputs.type }},${{ steps.derive.outputs.effort }},${{ steps.derive.outputs.start_date }}
 
       - name: Add or update aging and SLA annotation
         if: steps.preflight.outputs.enabled == 'true' && github.event.action != 'closed'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Added universal issue-field governance for `Priority`, `Start date`,
+  `Target date`, and `Effort`; aligned canonical config and instructions; and
+  automated project sync updates for `Effort` and `Start date`. ([#501](https://github.com/lightspeedwp/.github/pull/501))
+
 - CONTRIBUTING.md: removed forbidden `references` frontmatter field, corrected stale body date, and applied UK English consistency. Closes [#18](https://github.com/lightspeedwp/.github/issues/18). ([#457](https://github.com/lightspeedwp/.github/pull/457))
 - Clarified frontmatter version governance to use SemVer-aligned change
   classification with patch-first progression where appropriate, and aligned

--- a/docs/ISSUE-FIELDS.md
+++ b/docs/ISSUE-FIELDS.md
@@ -90,13 +90,61 @@ The org model includes:
 - `Domain` (`single_select`)
 - `Delivery Track` (`single_select`)
 - `Team` (`single_select`)
-- `Effort` (`number`)
+- `Effort` (`single_select`)
 - `Start date` (`date`)
 - `Target date` (`date`)
 - `Risk` (`single_select`)
 - `Customer Impact` (`single_select`)
 - `Technical Impact` (`single_select`)
 - `Spec Link` (`text`)
+
+## Canonical Universal Fields (Apply To All Issue Types)
+
+These fields are pinned for all issue types, including issues with no assigned type.
+
+Issue types covered:
+
+- Unassigned (no issue type)
+- Task, Bug, Feature, Code Refactor, Build & CI, A11y, Compatibility, Security, Release
+- Maintenance, Performance, Test Coverage, Epic, Automation, Code Review, Design, Story
+- Improvement, Documentation, Integration, Research, Chore, Audit, AI Ops, Content Modelling
+
+### 1) Priority
+
+- Purpose: Current importance level assigned to the issue.
+- Type: `single_select`
+- Allowed values: `Urgent`, `High`, `Medium`, `Low`
+- Scope: Applies to all issue types.
+
+### 2) Start date
+
+- Purpose: Date when work on the issue will begin.
+- Type: `date`
+- Scope: Applies to all issue types.
+- Constraint: Organization-only issue field.
+
+### 3) Target date
+
+- Purpose: Expected completion date for the issue.
+- Type: `date`
+- Scope: Applies to all issue types.
+- Constraint: Organization-only issue field.
+
+### 4) Effort
+
+- Purpose: Relative sizing estimate for implementation effort.
+- Type: `single_select`
+- Allowed values: `XS`, `S`, `M`, `L`, `XL`, `XXL`, `XXXL`
+- Scope: Applies to all issue types.
+- Constraint: Organization-only issue field.
+
+## How To Use These Fields During Triage
+
+- Set `Priority` on creation or first triage for every issue.
+- Set `Start date` when work is scheduled to begin.
+- Set `Target date` when there is a delivery expectation.
+- Set `Effort` as a T-shirt size estimate before planning or assignment.
+- Keep these issue fields aligned with labels and project fields during updates.
 
 ## Project Fields (Hidden/System + Iteration)
 

--- a/instructions/issues.instructions.md
+++ b/instructions/issues.instructions.md
@@ -2,8 +2,8 @@
 file_type: "instructions"
 title: "Issue Creation Instructions"
 description: "Canonical instructions for creating, labeling, and managing Issues in LightSpeedWP projects. Reference for templates, types, automation, and labeling strategy."
-version: "1.1"
-last_updated: "2025-12-04"
+version: "1.2"
+last_updated: "2026-05-28"
 owners: ["lightspeedwp/maintainers"]
 tags: ["issues", "templates", "frontmatter", "automation", "labels", "issue types", "triage", "branching"]
 ---
@@ -54,7 +54,7 @@ It covers templates, issue types, labels, frontmatter, and workflows, referencin
 - Templates are located in:  
   `.github/ISSUE_TEMPLATE/*.md`
 - **Do NOT use YAML Issue Forms**. All automation, labeling, and triage depend on Markdown-based templates.
-- See: [docs/frontmatter/issue-templates.md](../docs/frontmatter/issue-templates.md)
+- See: [Issue Creation Guide](../docs/ISSUE_CREATION_GUIDE.md)
 
 ---
 
@@ -196,7 +196,7 @@ labels: ["type:bug", "status:needs-triage", "priority:normal"]
 - `assignees`: Array of default assignees.
 - `projects`: Array of projects to auto-add the issue to.
 
-See [docs/frontmatter/issue-templates.md](../docs/frontmatter/issue-templates.md) for details.
+See [Issue Creation Guide](../docs/ISSUE_CREATION_GUIDE.md) for details.
 
 ---
 

--- a/instructions/issues.instructions.md
+++ b/instructions/issues.instructions.md
@@ -22,6 +22,9 @@ Applies to all issue templates and issue creation workflows. Covers frontmatter,
 - Include required frontmatter fields and one-hot `status:*`, `priority:*`, `type:*` labels.
 - Choose the correct template and complete all required sections/checklists.
 - Keep issues automation-friendly with links, acceptance criteria, and references.
+- Maximise metadata completeness on every issue update. Populate all applicable
+  metadata fields: labels, issue type, project fields, milestone, assignees,
+  projects, and parent-child or blocked-by relationships.
 
 ## Detailed Guidance
 
@@ -110,6 +113,23 @@ See [FRONTMATTER_SCHEMA.md](../docs/FRONTMATTER_SCHEMA.md) and [frontmatter.sche
 - **One** `type:*` (e.g., `type:bug`, `type:feature`, etc.) — matches org-wide [issue types](../docs/ISSUE_TYPES.md).
 - **One** `priority:*` (e.g., `priority:normal`) — urgency for scheduling and board mapping.
 - At least one `area:*` or `comp:*` if possible — for routing and discoverability.
+
+### Metadata Completeness Default
+
+- Treat metadata completeness as mandatory, not optional, during issue triage and updates.
+- Always set or verify issue type using canonical issue types and matching `type:*` label.
+- Always set or verify milestone when a release window, batch, or roadmap bucket is known.
+- Always set or verify project fields (for example `Status`, `Priority`, `Type`) when the issue is on a project board.
+- Always set or verify canonical issue fields from [docs/ISSUE-FIELDS.md](../docs/ISSUE-FIELDS.md):
+  - `Priority`: `Urgent`, `High`, `Medium`, `Low`
+  - `Start date`: date field (organization-only)
+  - `Target date`: date field (organization-only)
+  - `Effort`: `XS`, `S`, `M`, `L`, `XL`, `XXL`, `XXXL` (organization-only)
+- Always set or verify relationships where applicable:
+  - Parent issue or epic link
+  - Blocked-by or blocks dependencies
+  - Linked pull requests and related issues
+- If a metadata value cannot be inferred safely, leave it unchanged and record a short follow-up note describing what is missing.
 
 ### Label Families
 

--- a/instructions/pull-requests.instructions.md
+++ b/instructions/pull-requests.instructions.md
@@ -179,7 +179,7 @@ See [BRANCHING_STRATEGY.md](../docs/BRANCHING_STRATEGY.md) for full details and 
 ## 7. Reference Files and Checklists
 
 - **Templates:**
-  - [PULL_REQUEST_TEMPLATE.md](../.github/PULL_REQUEST_TEMPLATE.md)
+  - [pull_request_template.md](../.github/pull_request_template.md)
   - [All PR templates](../.github/PULL_REQUEST_TEMPLATE/)
 - **Labeling:**
   - [labeler.yml](../.github/labeler.yml)
@@ -248,7 +248,7 @@ For maintainers and reviewers, reference these [Saved Replies](../.github/SAVED_
 - [Branching Strategy](../docs/BRANCHING_STRATEGY.md)
 - [Label Definitions](../.github/labels.yml)
 - [Labeler Automation Rules](../.github/labeler.yml)
-- [PULL_REQUEST_TEMPLATE.md](../.github/PULL_REQUEST_TEMPLATE.md)
+- [pull_request_template.md](../.github/pull_request_template.md)
 - [All PR Templates](../.github/PULL_REQUEST_TEMPLATE/)
 - [Frontmatter Schema](../.schemas/frontmatter.schema.json)
 - [Frontmatter Schema Guide](../docs/FRONTMATTER_SCHEMA.md)

--- a/instructions/pull-requests.instructions.md
+++ b/instructions/pull-requests.instructions.md
@@ -2,8 +2,8 @@
 file_type: "instructions"
 title: "Pull Request Creation Instructions"
 description: "Canonical instructions for creating, labeling, and submitting Pull Requests in LightSpeedWP projects. Reference for templates, automation, and labeling strategy."
-version: "1.1"
-last_updated: "2025-10-23"
+version: "1.2"
+last_updated: "2026-05-28"
 owners: ["lightspeedwp/maintainers"]
 tags: ["pull requests", "templates", "frontmatter", "automation", "labels", "branching", "checklists"]
 ---
@@ -53,7 +53,7 @@ This document defines the standards, steps, and requirements for opening, labeli
   - `.github/PULL_REQUEST_TEMPLATE/*.md` (specific templates: feature, bugfix, chore, docs, release, etc.)
 - **Do NOT use YAML form PR templates.** All automation and labeling requires Markdown-based templates.
 
-See [docs/frontmatter/pr-templates.md](../docs/frontmatter/pr-templates.md) for specifications.
+See [PR Creation Process](../docs/PR_CREATION_PROCESS.md) for specifications.
 
 ---
 
@@ -82,7 +82,7 @@ labels: ["type:feature", "status:needs-review", "area:feature"]
 - `assignees`: Default assignees.
 - `projects`: Default project boards.
 
-See [frontmatter instructions](documentation-formats.instructions.md) and [frontmatter schema](../../schema/frontmatter.schema.json) for validation.
+See [frontmatter instructions](./documentation-formats.instructions.md) and [frontmatter schema](../.schemas/frontmatter.schema.json) for validation.
 
 ---
 
@@ -106,7 +106,7 @@ See [BRANCHING_STRATEGY.md](../docs/BRANCHING_STRATEGY.md) for full details and 
 1. **Update your branch** (rebase/merge latest main or develop).
 2. **Choose the correct PR template** when opening your PR. Templates are:
    - Bugfix, Feature, Chore, Docs, Build/CI, Refactor, Hotfix, Release, General, etc.
-   - For template details, see `.github/PULL_REQUEST_TEMPLATE/*.md` and [docs/frontmatter/pr-templates.md](../docs/frontmatter/pr-templates.md).
+   - For template details, see `.github/PULL_REQUEST_TEMPLATE/*.md` and [PR Creation Process](../docs/PR_CREATION_PROCESS.md).
 3. **Fill out all required fields** in the template:
    - **Linked issues:** Use `Closes #123` or similar.
    - **Description:** Clearly state *what* changed and *why*.

--- a/instructions/pull-requests.instructions.md
+++ b/instructions/pull-requests.instructions.md
@@ -22,6 +22,9 @@ Applies to all PR templates and submissions. Covers frontmatter, branching, temp
 - Follow branch naming patterns and ensure one-hot label families (`status:*`, `priority:*`, `release:*`, `type:*`).
 - Complete all template fields, checklists, and changelog sections.
 - Keep PRs automation-ready; monitor CI and respond to reviews promptly.
+- Maximise metadata completeness on every PR update. Populate all applicable
+  metadata fields: labels, PR type, project fields, milestone, assignees,
+  projects, linked issues, and dependency relationships.
 
 ## Detailed Guidance
 
@@ -145,6 +148,18 @@ See [BRANCHING_STRATEGY.md](../docs/BRANCHING_STRATEGY.md) for full details and 
   - PRs grouped and versioned based on `release:*` label ([release-label-guidance.md](../.github/SAVED_REPLIES/pull-requests/release-label-guidance.md))
   - Changelog section in PR description required ([changelog-required.md](../.github/SAVED_REPLIES/pull-requests/changelog-required.md))
   - Release workflow ([labeling.yml](../.github/workflows/labeling.yml)) automates changelog, labeling, and review steps.
+
+### Metadata Completeness Default
+
+- Treat metadata completeness as mandatory, not optional, during PR triage and updates.
+- Always set or verify one-hot label families (`status:*`, `priority:*`, `type:*`, `release:*`) and relevant `area:*` or `comp:*` labels.
+- Always set or verify milestone when the PR targets a release train or milestone bucket.
+- Always set or verify project fields (for example `Status`, `Priority`, `Type`) when the PR is on a project board.
+- Always set or verify relationships where applicable:
+  - Linked issues using closing keywords (`Closes #123`) when true
+  - Dependencies (`blocked by`, `depends on`) in PR body or linked issue graph
+  - Parent feature or epic issue references
+- If a metadata value cannot be inferred safely, leave it unchanged and record a short follow-up note describing what is missing.
 
 ---
 

--- a/scripts/agents/includes/derive-project-fields.cjs
+++ b/scripts/agents/includes/derive-project-fields.cjs
@@ -33,12 +33,21 @@ function main() {
   const eventName = process.env.EVENT_NAME || "";
   const eventAction = process.env.EVENT_ACTION || "";
   const prMerged = (process.env.PR_MERGED || "false").toLowerCase() === "true";
+  const itemCreatedAt = process.env.ITEM_CREATED_AT || "";
 
   const mappings = cfg.project_field_mappings || {};
+  const orgFields = cfg.organization_issue_fields || {};
+  const customFields = Array.isArray(orgFields.custom_fields)
+    ? orgFields.custom_fields
+    : [];
+  const effortField = customFields.find((field) => field?.key === "Effort") || {};
+  const effortDefault = typeof effortField.default === "string" ? effortField.default : "";
 
   let status = firstMatch(labels, mappings.Status);
   const priority = firstMatch(labels, mappings.Priority);
   let type = firstMatch(labels, mappings.Type);
+  let effort = effortDefault;
+  let startDate = "";
 
   if (eventName === "issues" && eventAction === "closed") {
     status = mappings.Status?.[cfg.defaults?.issue?.status_label_closed] || "Done";
@@ -52,11 +61,21 @@ function main() {
   if (!status) status = mappings.Status?.["status:needs-triage"] || "Triage";
   if (!type) type = "";
 
+  if (
+    itemCreatedAt &&
+    (eventAction === "opened" || eventAction === "reopened") &&
+    status !== "Done"
+  ) {
+    startDate = itemCreatedAt.slice(0, 10);
+  }
+
   const output = process.env.GITHUB_OUTPUT;
   const lines = [
     `status=${status}`,
     `priority=${priority || ""}`,
     `type=${type}`,
+    `effort=${effort || ""}`,
+    `start_date=${startDate}`,
   ];
 
   if (output) {

--- a/scripts/validation/validate-issue-fields.cjs
+++ b/scripts/validation/validate-issue-fields.cjs
@@ -127,7 +127,7 @@ function main() {
       if (!keySet.has(key)) fail(`Missing required custom field definition: ${key}`);
     }
 
-    const validTypes = new Set(['single_select', 'number', 'date', 'text']);
+    const validTypes = new Set(['single_select', 'date', 'text']);
     for (const field of customFields) {
       if (!field.key || typeof field.key !== 'string') fail('Each custom field requires a string key');
       if (!field.type || !validTypes.has(field.type)) {
@@ -179,10 +179,32 @@ function main() {
     'Type',
     'Sprint',
     'single_select',
-    'number',
     'date',
     'text',
   ];
+
+  const effortField = customFields.find((field) => field.key === 'Effort');
+  if (!effortField) {
+    fail('Missing required custom field definition: Effort');
+  } else {
+    if (effortField.type !== 'single_select') {
+      fail('Effort custom field must use type "single_select"');
+    }
+    const expectedEffort = ['XS', 'S', 'M', 'L', 'XL', 'XXL', 'XXXL'];
+    const gotEffort = Array.isArray(effortField.options) ? effortField.options : [];
+    for (const option of expectedEffort) {
+      if (!gotEffort.includes(option)) {
+        fail(`Effort custom field missing expected option: ${option}`);
+      }
+    }
+  }
+
+  const fieldUsage = orgFields.field_usage || {};
+  for (const key of ['Priority', 'Start date', 'Target date', 'Effort']) {
+    if (!fieldUsage[key]) {
+      fail(`organization_issue_fields.field_usage missing key: ${key}`);
+    }
+  }
 
   for (const needle of docMustContain) {
     if (!docRaw.includes(needle)) {


### PR DESCRIPTION
## Summary
- add canonical universal issue-field policy for Priority, Start date, Target date, and Effort
- update governance docs and issue instructions for full metadata completeness
- extend project meta sync workflow to update Effort and Start date automatically
- tighten issue-fields validation for new field constraints

## Validation
- node scripts/validation/validate-issue-fields.cjs

## Notes
- Target date remains manual to avoid unsafe automated completion-date guesses.