### PR TITLE
docs: consolidate GitHub workflow spec and active project issue pack

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_bug.md
@@ -53,7 +53,7 @@ Fixes #
 Required for release automation.
 Format: Keep a Changelog.
 Categories: Added, Changed, Fixed, Removed.
-User-facing notes only. Internal-only PRs (rare) may use the skip-changelog label.
+User-facing notes only. Internal-only PRs (rare) may use the `meta:no-changelog` label.
 Example:
 ### Changed
 - Switched to action/cache@v3 for build speedup. (Relates to #789)
@@ -84,7 +84,7 @@ Example:
 -->
 
 <!--
-If no user-facing changelog entry is needed, apply the skip-changelog label to this PR.
+If no user-facing changelog entry is needed, apply the `meta:no-changelog` label to this PR.
 -->
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/pr_chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_chore.md
@@ -46,7 +46,7 @@ Closes #
 Required for release automation.
 Format: Keep a Changelog.
 Categories: Added, Changed, Fixed, Removed.
-User-facing notes only. Internal-only PRs (rare) may use the skip-changelog label.
+User-facing notes only. Internal-only PRs (rare) may use the `meta:no-changelog` label.
 Example:
 ### Changed
 - Switched to action/cache@v3 for build speedup. (Relates to #789)
@@ -77,7 +77,7 @@ Example:
 -->
 
 <!--
-If no user-facing changelog entry is needed, apply the skip-changelog label to this PR.
+If no user-facing changelog entry is needed, apply the `meta:no-changelog` label to this PR.
 -->
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/pr_ci.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_ci.md
@@ -53,7 +53,7 @@ Relates to #
 Required for release automation.
 Format: Keep a Changelog.
 Categories: Added, Changed, Fixed, Removed.
-User-facing notes only. Internal-only PRs (rare) may use the skip-changelog label.
+User-facing notes only. Internal-only PRs (rare) may use the `meta:no-changelog` label.
 Example:
 ### Changed
 - Switched to action/cache@v3 for build speedup. (Relates to #789)
@@ -84,7 +84,7 @@ Example:
 -->
 
 <!--
-If no user-facing changelog entry is needed, apply the skip-changelog label to this PR.
+If no user-facing changelog entry is needed, apply the `meta:no-changelog` label to this PR.
 -->
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/pr_dep_update.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_dep_update.md
@@ -43,7 +43,7 @@ Relates to #
 Required for release automation.
 Format: Keep a Changelog.
 Categories: Added, Changed, Fixed, Removed.
-User-facing notes only. Internal-only PRs (rare) may use the skip-changelog label.
+User-facing notes only. Internal-only PRs (rare) may use the `meta:no-changelog` label.
 Example:
 ### Changed
 - Switched to action/cache@v3 for build speedup. (Relates to #789)
@@ -74,7 +74,7 @@ Example:
 -->
 
 <!--
-If no user-facing changelog entry is needed, apply the skip-changelog label to this PR.
+If no user-facing changelog entry is needed, apply the `meta:no-changelog` label to this PR.
 -->
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/pr_docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_docs.md
@@ -41,7 +41,7 @@ Relates to #
 Required for release automation.
 Format: Keep a Changelog.
 Categories: Added, Changed, Fixed, Removed.
-User-facing notes only. Internal-only PRs (rare) may use the skip-changelog label.
+User-facing notes only. Internal-only PRs (rare) may use the `meta:no-changelog` label.
 Example:
 ### Changed
 - Switched to action/cache@v3 for build speedup. (Relates to #789)
@@ -72,7 +72,7 @@ Example:
 -->
 
 <!--
-If no user-facing changelog entry is needed, apply the skip-changelog label to this PR.
+If no user-facing changelog entry is needed, apply the `meta:no-changelog` label to this PR.
 -->
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/pr_feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_feature.md
@@ -24,7 +24,7 @@ Closes #
 Required for release automation.
 Format: Keep a Changelog.
 Categories: Added, Changed, Fixed, Removed.
-User-facing notes only. Internal-only PRs (rare) may use the skip-changelog label.
+User-facing notes only. Internal-only PRs (rare) may use the `meta:no-changelog` label.
 Example:
 ### Changed
 - Switched to action/cache@v3 for build speedup. (Relates to #789)
@@ -55,7 +55,7 @@ Example:
 -->
 
 <!--
-If no user-facing changelog entry is needed, apply the skip-changelog label to this PR.
+If no user-facing changelog entry is needed, apply the `meta:no-changelog` label to this PR.
 -->
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/pr_hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_hotfix.md
@@ -31,7 +31,7 @@ Summarise the incident or bug and the root cause (add links if needed).
 Required for release automation.
 Format: Keep a Changelog.
 Categories: Added, Changed, Fixed, Removed.
-User-facing notes only. Internal-only PRs (rare) may use the skip-changelog label.
+User-facing notes only. Internal-only PRs (rare) may use the `meta:no-changelog` label.
 Example:
 ### Changed
 - Switched to action/cache@v3 for build speedup. (Relates to #789)
@@ -62,7 +62,7 @@ Example:
 -->
 
 <!--
-If no user-facing changelog entry is needed, apply the skip-changelog label to this PR.
+If no user-facing changelog entry is needed, apply the `meta:no-changelog` label to this PR.
 -->
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/pr_hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_hotfix.md
@@ -9,7 +9,7 @@ labels:
 # Hotfix Pull Request
 
 > This repository enforces changelog, release, and label automation for all PRs and issues.  
-> See the organisation-wide [Automation Governance & Release Strategy](https://github.com/lightspeedwp/.github/blob/main/AUTOMATION_GOVERNANCE.md) for contributor rules.
+> See the organisation-wide [Project Operations Spec](https://github.com/lightspeedwp/.github/blob/HEAD/docs/GITHUB_PROJECT_OPERATIONS_SPEC.md) for contributor rules.
 
 ## Linked issues
 

--- a/.github/PULL_REQUEST_TEMPLATE/pr_hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_hotfix.md
@@ -9,7 +9,7 @@ labels:
 # Hotfix Pull Request
 
 > This repository enforces changelog, release, and label automation for all PRs and issues.  
-> See the organisation-wide [Project Operations Spec](https://github.com/lightspeedwp/.github/blob/HEAD/docs/GITHUB_PROJECT_OPERATIONS_SPEC.md) for contributor rules.
+> See the organisation-wide [Project Operations Spec](../../docs/GITHUB_PROJECT_OPERATIONS_SPEC.md) for contributor rules.
 
 ## Linked issues
 

--- a/.github/PULL_REQUEST_TEMPLATE/pr_refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_refactor.md
@@ -53,7 +53,7 @@ Closes #
 Required for release automation.
 Format: Keep a Changelog.
 Categories: Added, Changed, Fixed, Removed.
-User-facing notes only. Internal-only PRs (rare) may use the skip-changelog label.
+User-facing notes only. Internal-only PRs (rare) may use the `meta:no-changelog` label.
 Example:
 ### Changed
 - Switched to action/cache@v3 for build speedup. (Relates to #789)
@@ -84,7 +84,7 @@ Example:
 -->
 
 <!--
-If no user-facing changelog entry is needed, apply the skip-changelog label to this PR.
+If no user-facing changelog entry is needed, apply the `meta:no-changelog` label to this PR.
 -->
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/pr_release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_release.md
@@ -26,7 +26,7 @@ Includes:
 Required for release automation.
 Format: Keep a Changelog.
 Categories: Added, Changed, Fixed, Removed.
-User-facing notes only. Internal-only PRs (rare) may use the skip-changelog label.
+User-facing notes only. Internal-only PRs (rare) may use the `meta:no-changelog` label.
 Example:
 ### Changed
 - Switched to action/cache@v3 for build speedup. (Relates to #789)
@@ -57,7 +57,7 @@ Example:
 -->
 
 <!--
-If no user-facing changelog entry is needed, apply the skip-changelog label to this PR.
+If no user-facing changelog entry is needed, apply the `meta:no-changelog` label to this PR.
 -->
 
 ---

--- a/.github/projects/active/github-workflow-consolidation-2026-05-28/README.md
+++ b/.github/projects/active/github-workflow-consolidation-2026-05-28/README.md
@@ -1,0 +1,40 @@
+# GitHub Workflow Consolidation (2026-05-28)
+
+## Scope
+
+Consolidate GitHub workflow governance into one lean, current spec that reflects live automation.
+
+This pack tracks:
+
+- Unified GitHub Project template guidance with profile presets.
+- Branching strategy slimdown and alignment to current `labeler.yml` automation.
+- Issue/PR metadata automation contract aligned to current workflows.
+- Targeted template/doc drift fixes only.
+
+## Goals
+
+- Reduce documentation bloat and legacy duplication.
+- Keep `labels -> project fields` behaviour explicit and current.
+- Keep automation compatibility intact with no structural workflow refactors.
+
+## Sequencing
+
+1. Publish canonical operations spec.
+2. Align existing docs to canonical spec.
+3. Apply targeted PR template wording fix for changelog skip label.
+4. Run validations and publish drift report.
+
+## Canonical References
+
+- `docs/GITHUB_PROJECT_OPERATIONS_SPEC.md`
+- `.github/issue-fields.yml`
+- `.github/labels.yml`
+- `.github/labeler.yml`
+- `.github/workflows/labeling.yml`
+- `.github/workflows/project-meta-sync.yml`
+
+## Deliverables
+
+- Parent epic issue and six child issue specs under `issues/`.
+- Updated docs and PR templates.
+- Validation evidence from markdown, labels, fields, and workflow checks.

--- a/.github/projects/active/github-workflow-consolidation-2026-05-28/drift-report-2026-05-28.md
+++ b/.github/projects/active/github-workflow-consolidation-2026-05-28/drift-report-2026-05-28.md
@@ -1,0 +1,41 @@
+# Drift Report - 2026-05-28
+
+## Scope
+
+GitHub workflow consolidation deliverables for docs, templates, and active project issue pack.
+
+## Rule-to-Source Trace
+
+- Canonical labels: `.github/labels.yml`
+- Branch/file label automation: `.github/labeler.yml`
+- Issue type mappings: `.github/issue-types.yml`
+- Project field mappings/defaults: `.github/issue-fields.yml`
+- Label automation workflow: `.github/workflows/labeling.yml`
+- Project field sync workflow: `.github/workflows/project-meta-sync.yml`
+
+## Drift Fixed
+
+1. Added canonical operations spec:
+   - `docs/GITHUB_PROJECT_OPERATIONS_SPEC.md`
+2. Updated contributor docs to reference canonical spec:
+   - `docs/BRANCHING_STRATEGY.md`
+   - `docs/ISSUE-FIELDS.md`
+   - `docs/PR_LABELS.md`
+   - `docs/LABEL_STRATEGY.md`
+3. Normalised changelog skip wording in PR templates to canonical label:
+   - `meta:no-changelog`
+4. Created active issue pack:
+   - `.github/projects/active/github-workflow-consolidation-2026-05-28/`
+
+## Validation Evidence
+
+- `npx markdownlint-cli2 "**/*.md"` -> pass
+- `git diff --check` -> pass
+- `node scripts/agents/includes/check-template-labels.js` -> pass
+- `node scripts/validation/validate-labeling-configs.cjs` -> pass
+- `node scripts/validation/validate-issue-fields.cjs` -> pass
+- `npm run validate:workflows` -> pass (warnings only; no failures)
+
+## Notes
+
+Workflow validation warnings are existing optimisation and hygiene suggestions (for example concurrency/caching naming guidance), not hard failures introduced by this change set.

--- a/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/README.md
+++ b/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/README.md
@@ -1,0 +1,22 @@
+# Issue Pack README
+
+This folder contains issue-ready markdown for the GitHub workflow consolidation workstream.
+
+## Structure
+
+- `parents/`: parent epic issue.
+- `children/`: executable child issues linked to the parent.
+
+## Posting Workflow
+
+1. Create the parent epic issue first.
+2. Create child issues in numeric order.
+3. Link each child to the parent (`github_parent`) and add child links back into the parent file.
+4. Keep canonical labels only (`status:*`, `priority:*`, `type:*`, optional `area:*`).
+
+## Validation Before Posting
+
+- `node scripts/agents/includes/check-template-labels.js`
+- `node scripts/validation/validate-labeling-configs.cjs`
+- `node scripts/validation/validate-issue-fields.cjs`
+- `npm run validate:workflows`

--- a/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/01-docs-unify-project-template-and-governance-spec.md
+++ b/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/01-docs-unify-project-template-and-governance-spec.md
@@ -1,0 +1,42 @@
+---
+name: "Task"
+about: "Request or propose focused implementation work"
+title: "[Task] Unify project template and governance into one canonical operations spec"
+labels: [status:needs-review, priority:important, type:documentation, area:documentation]
+github_parent: "https://github.com/lightspeedwp/.github/issues/503"
+github_issue: "https://github.com/lightspeedwp/.github/issues/504"
+---
+
+## Deliverable
+
+Create `docs/GITHUB_PROJECT_OPERATIONS_SPEC.md` as the canonical, non-duplicative governance spec for branching, metadata automation, and unified project template usage.
+
+## Scope Boundary
+
+- In scope: docs consolidation and migration mapping from legacy 2025 strategy docs.
+- Out of scope: workflow architecture changes.
+
+## Acceptance Checklist
+
+- [ ] Canonical spec created with clear sections and links to live config/workflows.
+- [ ] Unified project template model documented with profile presets (`client_delivery`, `product_delivery`).
+- [ ] Legacy doc mapping section added (deprecated vs retained).
+- [ ] No duplicated rule definitions that conflict with `.github/*.yml` configs.
+
+## Branch Prefix Expectation
+
+- Use `docs/`.
+
+## Validation Commands
+
+```bash
+npx markdownlint-cli2 "docs/GITHUB_PROJECT_OPERATIONS_SPEC.md"
+git diff --check
+```
+
+## Touched Paths
+
+- `docs/GITHUB_PROJECT_OPERATIONS_SPEC.md`
+- `.github/issue-fields.yml`
+- `.github/labels.yml`
+- `.github/labeler.yml`

--- a/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/02-docs-branching-strategy-slimdown-and-alignment.md
+++ b/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/02-docs-branching-strategy-slimdown-and-alignment.md
@@ -1,0 +1,41 @@
+---
+name: "Task"
+about: "Request or propose focused implementation work"
+title: "[Task] Slim down branching strategy and align with live labeler rules"
+labels: [status:needs-review, priority:important, type:documentation, area:documentation]
+github_parent: "https://github.com/lightspeedwp/.github/issues/503"
+github_issue: "https://github.com/lightspeedwp/.github/issues/505"
+---
+
+## Deliverable
+
+Update branching documentation to explicitly separate required core prefixes from optional profile prefixes and align with current automation.
+
+## Scope Boundary
+
+- In scope: documentation clarity and consistency updates.
+- Out of scope: changing branch-prefix behaviour in workflows.
+
+## Acceptance Checklist
+
+- [ ] Required core prefix set is explicit and concise.
+- [ ] Optional profile prefixes for client/product contexts are explicit.
+- [ ] References point to canonical spec and `.github/labeler.yml`.
+- [ ] No contradictions with current labeler branch regex.
+
+## Branch Prefix Expectation
+
+- Use `docs/`.
+
+## Validation Commands
+
+```bash
+npx markdownlint-cli2 "docs/BRANCHING_STRATEGY.md" "docs/GITHUB_PROJECT_OPERATIONS_SPEC.md"
+git diff --check
+```
+
+## Touched Paths
+
+- `docs/BRANCHING_STRATEGY.md`
+- `docs/GITHUB_PROJECT_OPERATIONS_SPEC.md`
+- `.github/labeler.yml`

--- a/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/03-docs-project-meta-sync-contract-current-state.md
+++ b/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/03-docs-project-meta-sync-contract-current-state.md
@@ -1,0 +1,42 @@
+---
+name: "Task"
+about: "Request or propose focused implementation work"
+title: "[Task] Document current-state project-meta-sync contract"
+labels: [status:needs-review, priority:normal, type:documentation, area:documentation]
+github_parent: "https://github.com/lightspeedwp/.github/issues/503"
+github_issue: "https://github.com/lightspeedwp/.github/issues/506"
+---
+
+## Deliverable
+
+Document current project-meta-sync behaviour as-is, including preflight requirements and Status/Priority/Type field sync boundaries.
+
+## Scope Boundary
+
+- In scope: documentation of current behaviour.
+- Out of scope: extending synced fields or workflow refactors.
+
+## Acceptance Checklist
+
+- [ ] Preflight requirements are documented (`LS_PROJECT_URL`, `LS_APP_ID`, `LS_APP_PRIVATE_KEY`).
+- [ ] Synced fields explicitly limited to Status, Priority, Type.
+- [ ] Close/merge status handling and defaults are documented.
+- [ ] References point to canonical workflow and field mapping YAML.
+
+## Branch Prefix Expectation
+
+- Use `docs/`.
+
+## Validation Commands
+
+```bash
+npx markdownlint-cli2 "docs/ISSUE-FIELDS.md" "docs/GITHUB_PROJECT_OPERATIONS_SPEC.md"
+node scripts/validation/validate-issue-fields.cjs
+```
+
+## Touched Paths
+
+- `docs/ISSUE-FIELDS.md`
+- `docs/GITHUB_PROJECT_OPERATIONS_SPEC.md`
+- `.github/workflows/project-meta-sync.yml`
+- `.github/issue-fields.yml`

--- a/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/04-docs-issue-pr-metadata-automation-contract.md
+++ b/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/04-docs-issue-pr-metadata-automation-contract.md
@@ -1,0 +1,43 @@
+---
+name: "Task"
+about: "Request or propose focused implementation work"
+title: "[Task] Document issue and PR metadata automation contract"
+labels: [status:needs-review, priority:important, type:documentation, area:documentation]
+github_parent: "https://github.com/lightspeedwp/.github/issues/503"
+github_issue: "https://github.com/lightspeedwp/.github/issues/507"
+---
+
+## Deliverable
+
+Document the canonical issue/PR metadata contract based on live labeling automation, template guardrails, and project field sync.
+
+## Scope Boundary
+
+- In scope: contributor-facing contract and reference links.
+- Out of scope: introducing new label families or required fields.
+
+## Acceptance Checklist
+
+- [ ] One-hot expectations for `status:*`, `priority:*`, and `type:*` are explicit.
+- [ ] Changelog meta label policy uses canonical names.
+- [ ] PR/issue template guidance references live guardrails.
+- [ ] Cross-links to canonical spec and current workflow/config files are present.
+
+## Branch Prefix Expectation
+
+- Use `docs/`.
+
+## Validation Commands
+
+```bash
+npx markdownlint-cli2 "docs/PR_LABELS.md" "docs/LABEL_STRATEGY.md" "docs/GITHUB_PROJECT_OPERATIONS_SPEC.md"
+node scripts/agents/includes/check-template-labels.js
+```
+
+## Touched Paths
+
+- `docs/PR_LABELS.md`
+- `docs/LABEL_STRATEGY.md`
+- `docs/GITHUB_PROJECT_OPERATIONS_SPEC.md`
+- `.github/labels.yml`
+- `.github/labeler.yml`

--- a/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/05-refactor-pr-template-changelog-label-wording-alignment.md
+++ b/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/05-refactor-pr-template-changelog-label-wording-alignment.md
@@ -1,0 +1,40 @@
+---
+name: "Code Refactor"
+about: "Request or propose a code refactoring or review to improve code quality, maintainability, and consistency."
+title: "[Refactor] Align PR template changelog-skip wording with canonical meta label"
+labels: [status:needs-review, priority:normal, type:refactor, area:automation]
+github_parent: "https://github.com/lightspeedwp/.github/issues/503"
+github_issue: "https://github.com/lightspeedwp/.github/issues/508"
+---
+
+## Deliverable
+
+Update PR template wording so all changelog-skip references consistently use canonical `meta:no-changelog`.
+
+## Scope Boundary
+
+- In scope: wording-only template alignment.
+- Out of scope: workflow logic changes.
+
+## Acceptance Checklist
+
+- [ ] All PR templates use `meta:no-changelog` wording consistently.
+- [ ] No template references `skip-changelog` as the canonical label.
+- [ ] Existing template structure and checklists remain intact.
+
+## Branch Prefix Expectation
+
+- Use `refactor/`.
+
+## Validation Commands
+
+```bash
+rg -n "skip-changelog|meta:no-changelog" .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE -S
+node scripts/agents/includes/check-template-labels.js
+git diff --check
+```
+
+## Touched Paths
+
+- `.github/pull_request_template.md`
+- `.github/PULL_REQUEST_TEMPLATE/*.md`

--- a/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/06-validation-run-and-drift-report.md
+++ b/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/children/06-validation-run-and-drift-report.md
@@ -1,0 +1,49 @@
+---
+name: "Task"
+about: "Request or propose focused implementation work"
+title: "[Task] Run validation suite and publish drift report"
+labels: [status:needs-review, priority:important, type:task, area:testing]
+github_parent: "https://github.com/lightspeedwp/.github/issues/503"
+github_issue: "https://github.com/lightspeedwp/.github/issues/509"
+---
+
+## Deliverable
+
+Run the agreed validation commands and publish a concise drift report that confirms doc rules trace to live automation/config files.
+
+## Scope Boundary
+
+- In scope: validation execution and report.
+- Out of scope: new feature work.
+
+## Acceptance Checklist
+
+- [ ] Markdown lint checks executed.
+- [ ] Template-label and config validators pass.
+- [ ] Workflow validation command executed.
+- [ ] Drift report lists each canonical rule and its source file.
+
+## Branch Prefix Expectation
+
+- Use `test/`.
+
+## Validation Commands
+
+```bash
+npx markdownlint-cli2 "**/*.md"
+git diff --check
+node scripts/agents/includes/check-template-labels.js
+node scripts/validation/validate-labeling-configs.cjs
+node scripts/validation/validate-issue-fields.cjs
+npm run validate:workflows
+```
+
+## Touched Paths
+
+- `.github/projects/active/github-workflow-consolidation-2026-05-28/`
+- `docs/GITHUB_PROJECT_OPERATIONS_SPEC.md`
+- `.github/issue-fields.yml`
+- `.github/labels.yml`
+- `.github/labeler.yml`
+- `.github/workflows/labeling.yml`
+- `.github/workflows/project-meta-sync.yml`

--- a/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/parents/01-epic-github-workflow-consolidation.md
+++ b/.github/projects/active/github-workflow-consolidation-2026-05-28/issues/parents/01-epic-github-workflow-consolidation.md
@@ -1,0 +1,48 @@
+---
+name: "Epic"
+about: "Propose/manage a large, multi-part initiative or project grouping stories/features/tasks"
+title: "[Epic] Consolidate GitHub workflow docs and active project pack"
+labels: [status:needs-planning, priority:important, type:task, area:documentation]
+github_issue: "https://github.com/lightspeedwp/.github/issues/503"
+---
+
+## Epic Objective
+
+Deliver a lean, current, and automation-aligned GitHub workflow documentation baseline plus an active project issue pack that can be posted directly.
+
+## Linked Stories/Tasks
+
+- [ ] [#504](https://github.com/lightspeedwp/.github/issues/504) 01 Docs unify project template and governance spec
+- [ ] [#505](https://github.com/lightspeedwp/.github/issues/505) 02 Branching strategy slimdown and alignment
+- [ ] [#506](https://github.com/lightspeedwp/.github/issues/506) 03 Project-meta-sync contract (current-state)
+- [ ] [#507](https://github.com/lightspeedwp/.github/issues/507) 04 Issue/PR metadata automation contract
+- [ ] [#508](https://github.com/lightspeedwp/.github/issues/508) 05 PR template changelog-label wording alignment
+- [ ] [#509](https://github.com/lightspeedwp/.github/issues/509) 06 Validation run and drift report
+
+## Acceptance Criteria
+
+- [ ] Canonical operations spec exists and is the primary reference.
+- [ ] Existing docs are updated to reference the canonical spec.
+- [ ] Branching guidance clearly separates required core prefixes from optional profile prefixes.
+- [ ] PR templates consistently use canonical `meta:no-changelog` wording.
+- [ ] Active project issue pack exists under `.github/projects/active/`.
+- [ ] Validation commands pass and evidence is captured.
+
+## Dependencies / Blockers
+
+- Canonical labels and mappings remain sourced from `.github/labels.yml`, `.github/labeler.yml`, and `.github/issue-fields.yml`.
+- No structural refactor of `labeling.yml` or `project-meta-sync.yml` in this epic.
+
+## Definition of Ready (DoR)
+
+- [ ] Objective and boundaries documented.
+- [ ] Child task list complete.
+- [ ] Validation plan defined.
+- [ ] Canonical source files identified.
+
+## Definition of Done (DoD)
+
+- [ ] All child tasks complete.
+- [ ] Docs and templates updated and validated.
+- [ ] Drift report added.
+- [ ] Workstream ready for issue posting and execution.

--- a/docs/BRANCHING_STRATEGY.md
+++ b/docs/BRANCHING_STRATEGY.md
@@ -1,5 +1,7 @@
 # Org-wide Git Branching Strategy
 
+Primary operations reference: [GITHUB_PROJECT_OPERATIONS_SPEC.md](./GITHUB_PROJECT_OPERATIONS_SPEC.md)
+
 <!-- BADGES-START -->
 
 [![changelog](https://github.com/lightspeedwp/.github/actions/workflows/changelog.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/changelog.yml)
@@ -56,7 +58,7 @@ Enable squash merge only; disable merge commits and rebase merges.
 `{type}/{scope}-{short-title}`  
 Use lower-case, kebab-case, and keep it short.
 
-### 3.1 Shared Core Prefixes
+### 3.1 Required Core Prefixes
 
 For all repos (client, product, infra, etc.), use:
 
@@ -81,7 +83,7 @@ For all repos (client, product, infra, etc.), use:
 - `i18n/` — internationalization
 - `ops/` — operations
 
-### 3.2 Product-specific Prefixes (optional)
+### 3.2 Optional Product Profile Prefixes
 
 - `proto/` — prototypes/experiments
 - `ds/` — design system
@@ -89,7 +91,7 @@ For all repos (client, product, infra, etc.), use:
 - `schema/` — DB/schema changes
 - `telemetry/` — analytics/metrics
 
-### 3.3 Client-specific Prefixes (optional)
+### 3.3 Optional Client Profile Prefixes
 
 - `content/` — content edits, redirects, IA
 - `seo/` — SEO, metadata, schema, sitemap, robots

--- a/docs/BRANCHING_STRATEGY.md
+++ b/docs/BRANCHING_STRATEGY.md
@@ -278,16 +278,16 @@ Issue Types and Project fields carry the semantic meaning.
 - [BRANCHING_STRATEGY.md](./BRANCHING_STRATEGY.md): Org-wide branch naming, merge discipline, and automation mapping.
 - [CHANGELOG.md](../CHANGELOG.md): Changelog format, release notes, and versioning.
 - [CONTRIBUTING.md](../CONTRIBUTING.md): Contribution guidelines, templates, and coding standards.
-- [AUTOMATION_GOVERNANCE.md](./AUTOMATION_GOVERNANCE.md): Org-wide automation, labeling, and release strategy.
+- [GITHUB_PROJECT_OPERATIONS_SPEC.md](./GITHUB_PROJECT_OPERATIONS_SPEC.md): Org-wide project operations, labeling, and release guidance.
 - [ISSUE_TYPES.md](./ISSUE_TYPES.md): Issue type mapping and usage.
 - [ISSUE_LABELS.md](./ISSUE_LABELS.md): Label families, triage, and workflow.
 - [PR_LABELS.md](./PR_LABELS.md): PR labeling, templates, and automation.
-- [custom-instructions.md](./custom-instructions.md): Copilot and agent instructions.
-- [instructions/linting.instructions.md](./instructions/linting.instructions.md): Linting index and tool guidance.
-- [instructions/coding-standards.instructions.md](./instructions/coding-standards.instructions.md): Coding standards index.
-- [instructions/documentation-formats.instructions.md](./instructions/documentation-formats.instructions.md): Frontmatter schema and conventions.
+- [.github/custom-instructions.md](../.github/custom-instructions.md): Copilot and agent instructions.
+- [instructions/linting.instructions.md](../instructions/linting.instructions.md): Linting index and tool guidance.
+- [instructions/coding-standards.instructions.md](../instructions/coding-standards.instructions.md): Coding standards index.
+- [instructions/documentation-formats.instructions.md](../instructions/documentation-formats.instructions.md): Frontmatter schema and conventions.
 - [GitHub Custom Instructions](https://github.com/lightspeedwp/.github/blob/HEAD/.github/custom-instructions.md): Org-wide guidance and AI agent usage.
-- [Pull Request Template](https://github.com/lightspeedwp/.github/blob/HEAD/.github/PULL_REQUEST_TEMPLATE.md): PR summary and best practices.
+- [Pull Request Template](https://github.com/lightspeedwp/.github/blob/HEAD/.github/pull_request_template.md): PR summary and best practices.
 
 ---
 

--- a/docs/GITHUB_PROJECT_OPERATIONS_SPEC.md
+++ b/docs/GITHUB_PROJECT_OPERATIONS_SPEC.md
@@ -1,0 +1,122 @@
+# GitHub Project Operations Spec
+
+Canonical source for LightSpeed GitHub project operations across issue and PR metadata, branching conventions, and GitHub Projects usage.
+
+## Purpose
+
+Keep contributor docs lean and current by describing operational rules while treating live config and workflows as the source of automation truth.
+
+## Canonical Automation Sources
+
+- `.github/labels.yml` (canonical labels)
+- `.github/labeler.yml` (branch/file-to-label mappings)
+- `.github/issue-types.yml` (issue-type mappings)
+- `.github/issue-fields.yml` (project field mappings and defaults)
+- `.github/workflows/labeling.yml` (label automation)
+- `.github/workflows/project-meta-sync.yml` (project field sync)
+
+## Unified Project Template Model
+
+Use one unified template with two profile presets:
+
+- `client_delivery`
+- `product_delivery`
+
+Both profiles share one field model and one automation contract. Profile differences should stay in view presets, milestones, and cadence naming only.
+
+### Shared Baseline
+
+- Fields: `Status`, `Priority`, `Type`, `Start date`, `Target date`, `Parent issue`, `Sub-issue progress`, plus approved custom issue fields from `.github/issue-fields.yml`.
+- One issue type per issue.
+- Labels are routing and automation signals; fields are project operating state.
+
+### Profile Deltas
+
+- `client_delivery`: UAT and go-live naming emphasis (for example milestone naming and views).
+- `product_delivery`: release train emphasis (for example `vX.Y.Z` milestone views).
+
+## Branching Contract
+
+### Required Core Prefixes
+
+`feat/`, `fix/`, `hotfix/`, `release/`, `refactor/`, `chore/`, `docs/`, `test/`, `perf/`, `ci/`, `build/`, `deps/`, `security/`, `revert/`, `research/`, `design/`, `a11y/`, `ux/`, `i18n/`, `ops/`
+
+### Optional Profile Prefixes
+
+- Product-oriented optional: `proto/`, `ds/`, `api/`, `schema/`, `telemetry/`
+- Client-oriented optional: `content/`, `seo/`, `config/`, `migrate/`, `qa/`, `uat/`
+
+Rule: branch guidance must remain aligned to actual prefix handling in `.github/labeler.yml`.
+
+## Issue and PR Metadata Contract
+
+### Required Label Families
+
+For issues and PRs, enforce one-hot families:
+
+- exactly one `status:*`
+- exactly one `priority:*`
+- exactly one `type:*`
+
+Use at least one scope label where relevant (`area:*` or `comp:*`).
+
+### Changelog Meta Labels
+
+- `meta:needs-changelog`: default for user-facing work.
+- `meta:no-changelog`: internal-only changes with no user-facing impact.
+- Never apply both on the same item.
+
+### Template Guardrails
+
+Template labels must remain canonical and pass:
+
+- `node scripts/agents/includes/check-template-labels.js`
+
+## Project Meta Sync Contract (Current State)
+
+`project-meta-sync.yml` currently synchronises project fields from labels for:
+
+- `Status`
+- `Priority`
+- `Type`
+
+Current preflight conditions must be satisfied before sync runs:
+
+- `LS_PROJECT_URL`
+- `LS_APP_ID`
+- `LS_APP_PRIVATE_KEY`
+
+No additional fields are in scope for this spec.
+
+## Minimum Validation Set
+
+```bash
+npx markdownlint-cli2 "**/*.md"
+git diff --check
+node scripts/agents/includes/check-template-labels.js
+node scripts/validation/validate-labeling-configs.cjs
+node scripts/validation/validate-issue-fields.cjs
+npm run validate:workflows
+```
+
+## Migration Mapping (2025 docs -> current canonical sections)
+
+- `GitHub-Branching-Strategy.md` -> Branching Contract
+- `GitHub-Label-Automation-Strategy.md` -> Metadata Contract + Canonical Automation Sources
+- `GitHub-Project-Field-Defaults.md` -> Unified Template Model + Project Meta Sync Contract
+- `GitHub-Project-Views.md` -> Profile Deltas and local project view presets
+- `Projects-Client-Delivery-Project-Template*.md` -> Unified Template Model + `client_delivery` profile
+- `Projects-Product-Delivery-Project-Template*.md` -> Unified Template Model + `product_delivery` profile
+
+## Retained vs Deprecated Guidance
+
+Retained:
+
+- branch-to-label automation
+- label-first metadata discipline
+- project field synchronisation from canonical mappings
+
+Deprecated:
+
+- maintaining separate long-form client and product template document suites
+- duplicate strategy docs that restate YAML workflow logic instead of referencing canonical sources

--- a/docs/ISSUE-FIELDS.md
+++ b/docs/ISSUE-FIELDS.md
@@ -1,5 +1,7 @@
 # Canonical Issue Fields
 
+Primary operations reference: [GITHUB_PROJECT_OPERATIONS_SPEC.md](./GITHUB_PROJECT_OPERATIONS_SPEC.md)
+
 This document explains how LightSpeedWP defines and operates canonical GitHub issue/project fields.
 
 Source of truth:

--- a/docs/LABEL_STRATEGY.md
+++ b/docs/LABEL_STRATEGY.md
@@ -147,7 +147,7 @@ This document describes how LightSpeed uses GitHub labels to power automation, s
 - Use the most specific `area:*` or `comp:*` for filtering.
 - Update labels as work progresses or scope changes.
 - Review and clean up labels quarterly; remove unused or redundant entries.
-- Reference [labeling.agent.md](./agents/labeling.agent.md) for agent logic details.
+- Reference [labeling.agent.md](../agents/labeling.agent.md) for agent logic details.
 - See `.github/labels.yml`, `.github/labeler.yml`, and `.github/issue-types.yml` for configs.
 
 ---
@@ -164,7 +164,7 @@ This document describes how LightSpeed uses GitHub labels to power automation, s
 
 ## 8. References
 
-- [Automation Governance](./AUTOMATION_GOVERNANCE.md)
+- [Project Operations Spec](./GITHUB_PROJECT_OPERATIONS_SPEC.md)
 - [Issue Labels Guide](./ISSUE_LABELS.md)
 - [Canonical Labels & Colours](../.github/labels.yml)
 - [Labeler rules](../.github/labeler.yml)

--- a/docs/LABEL_STRATEGY.md
+++ b/docs/LABEL_STRATEGY.md
@@ -4,6 +4,8 @@
 
 # LightSpeed GitHub Labelling Strategy
 
+Primary operations reference: [GITHUB_PROJECT_OPERATIONS_SPEC.md](./GITHUB_PROJECT_OPERATIONS_SPEC.md)
+
 This document describes how LightSpeed uses GitHub labels to power automation, search, workflow routing, and community management across all repositories—including issues, pull requests (PRs), and discussions.
 
 ---

--- a/docs/PR_LABELS.md
+++ b/docs/PR_LABELS.md
@@ -1,114 +1,45 @@
-# .github/PR_LABELS.md
+# PR Labels
 
-<!-- BADGES-START -->
+Canonical contributor-facing guide for PR metadata labels.
 
-[![changelog](https://github.com/lightspeedwp/.github/actions/workflows/changelog.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/changelog.yml)
-[![issues](https://github.com/lightspeedwp/.github/actions/workflows/issues.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/issues.yml)
-[![labeling](https://github.com/lightspeedwp/.github/actions/workflows/labeling.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/labeling.yml)
-[![linting](https://github.com/lightspeedwp/.github/actions/workflows/linting.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/linting.yml)
-[![meta](https://github.com/lightspeedwp/.github/actions/workflows/meta.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/meta.yml)
-[![metrics](https://github.com/lightspeedwp/.github/actions/workflows/metrics.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/metrics.yml)
-[![planner](https://github.com/lightspeedwp/.github/actions/workflows/planner.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/planner.yml)
-[![project-meta-sync](https://github.com/lightspeedwp/.github/actions/workflows/project-meta-sync.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/project-meta-sync.yml)
-[![release](https://github.com/lightspeedwp/.github/actions/workflows/release.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/release.yml)
-[![reporting](https://github.com/lightspeedwp/.github/actions/workflows/reporting.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/reporting.yml)
-[![reviewer](https://github.com/lightspeedwp/.github/actions/workflows/reviewer.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/reviewer.yml)
-[![testing](https://github.com/lightspeedwp/.github/actions/workflows/testing.yml/badge.svg?branch=develop)](https://github.com/lightspeedwp/.github/actions/workflows/testing.yml)
+Primary operations reference: [GITHUB_PROJECT_OPERATIONS_SPEC.md](./GITHUB_PROJECT_OPERATIONS_SPEC.md)
 
-<!-- BADGES-END -->
+## Source of Truth
 
-> **Note:** All PR labeling, status, type, and standardization is handled by the unified labeling agent and labeling workflow. The canonical PR labels and assignment rules are maintained in ../.github/labels.yml and ../.github/labeler.yml.
+- `.github/labels.yml`
+- `.github/labeler.yml`
+- `.github/issue-types.yml`
+- `.github/workflows/labeling.yml`
 
----
+## Required PR Metadata
 
-## Purpose
+Each PR should have:
 
-Defines the org-wide standard for high-signal, automated **PR labeling** for review routing, release hygiene, and search in LightSpeed projects.
-Use this reference for consistent, correct PR labels and full alignment with automation.
+- exactly one `status:*`
+- exactly one `priority:*`
+- exactly one `type:*`
+- at least one scope label where relevant (`area:*` or `comp:*`)
 
----
+## Branch Prefix Expectations
 
-## Branch Prefixes
+Required core prefixes:
 
-Every PR should use a standard branch prefix for correct label and template automation:
+`feat/`, `fix/`, `hotfix/`, `release/`, `refactor/`, `chore/`, `docs/`, `test/`, `perf/`, `ci/`, `build/`, `deps/`, `security/`, `revert/`, `research/`, `design/`, `a11y/`, `ux/`, `i18n/`, `ops/`
 
-| Prefix    | Purpose                    | Maps to Type / Label | PR Template                                    |
-| --------- | -------------------------- | -------------------- | ---------------------------------------------- |
-| fix/      | Bugfix or regression       | bug                  | .github/PULL_REQUEST_TEMPLATE/pr_bug.md        |
-| chore/    | Maintenance/hygiene tasks  | chore                | .github/PULL_REQUEST_TEMPLATE/pr_chore.md      |
-| ci/       | CI/CD or workflow changes  | ci                   | .github/PULL_REQUEST_TEMPLATE/pr_ci.md         |
-| ci/       | CI/CD or workflow changes  | ci                   | .github/PULL_REQUEST_TEMPLATE/pr_dep_update.md |
-| docs/     | Documentation changes      | documentation        | .github/PULL_REQUEST_TEMPLATE/pr_docs.md       |
-| hotfix/   | Emergency production fix   | hotfix / bug         | .github/PULL_REQUEST_TEMPLATE/pr_hotfix.md     |
-| feat/     | New feature or enhancement | feature              | .github/PULL_REQUEST_TEMPLATE/pr_feature.md    |
-| refactor/ | Internal code refactoring  | refactor             | .github/PULL_REQUEST_TEMPLATE/pr_refactor.md   |
-| release/  | Release prep/deployment    | release              | .github/PULL_REQUEST_TEMPLATE/pr_release.md    |
+Optional profile prefixes (when relevant to the project):
 
-### Branch specific PR Templates to be created
+- Product: `proto/`, `ds/`, `api/`, `schema/`, `telemetry/`
+- Client: `content/`, `seo/`, `config/`, `migrate/`, `qa/`, `uat/`
 
-| Prefix    | Purpose                     | Maps to Type / Label | PR Template to be created                          |
-| --------- | --------------------------- | -------------------- | -------------------------------------------------- |
-| build/    | Build/CI/automation changes | build / ci           | .github/PULL_REQUEST_TEMPLATE/pr_build.md          |
-| test/     | Add or update tests         | test                 | .github/PULL_REQUEST_TEMPLATE/pr_test.md           |
-| design/   | Design changes/assets       | design               | .github/PULL_REQUEST_TEMPLATE/pr_design.md         |
-| research/ | Technical spike/research    | research             | .github/PULL_REQUEST_TEMPLATE/pr_research.md       |
-| perf/     | Performance improvements    | performance          | .github/PULL_REQUEST_TEMPLATE/pr_performance.md    |
-| --------- | --------------------------- | -------------------- | -------------------------------------------------- |
+## Changelog Meta Policy
 
----
+- Use `meta:needs-changelog` for user-facing changes.
+- Use `meta:no-changelog` only for internal-only changes with no user-facing impact.
+- Never apply both on the same PR.
 
-## PR Templates & Usage
+## Validation
 
-- Select the correct template for your PR type.
-- **Labels** are set automatically by the [unified agent and workflow](../.github/workflows/labeling.yml).
-- Each PR must have:
-  - Exactly one `status:*` (e.g., `status:needs-review`)
-  - Exactly one `priority:*`
-  - Exactly one `type:*`
-  - At least one `area:*` or `comp:*`
-  - A canonical release label (`release:patch`, etc.) for shipping PRs
-
----
-
-## Label Automation
-
-- All label assignment, enforcement, and standardization is handled by the **unified labeling agent** ([labeling.agent.js](../scripts/agents/labeling.agent.js)).
-- **File/branch-based rules** are defined in [labeler.yml](../.github/labeler.yml).
-- **Non-canonical or legacy labels** are automatically removed or migrated.
-
----
-
-## Release & Changelog Process
-
-- Changelog labels are mutually exclusive: never apply both `meta:needs-changelog` and `meta:no-changelog`.
-- Use `meta:no-changelog` only for internal-only changes (for example docs, refactor, chore, or test work with no user-facing impact).
-- Do not use `meta:no-changelog` on `type:feature`, `type:bug`, `type:performance`, `type:security`, `type:release`, or `type:hotfix` PRs.
-- PRs affecting user-facing features/fixes must carry changelog content and should not use `meta:no-changelog`.
-- Only one `status:*` and one `release:*` label per PR.
-- See [labels.yml](../.github/labels.yml) for the current canonical options.
-
----
-
-## Usage Notes
-
-- All PR labeling, status, type, and standardization is automated and validated; maintainers may adjust as needed.
-- For a full list of canonical PR labels and colors, see [labels.yml](../.github/labels.yml).
-
----
-
-## References
-
-- [labels.yml](../.github/labels.yml)
-- [labeler.yml](../.github/labeler.yml)
-- [issue-types.yml](../.github/issue-types.yml)
-- [labeling.agent.md](../agents/labeling.agent.md)
-- [labeling.yml](../.github/workflows/labeling.yml)
-- [Labeling Strategy](./LABEL_STRATEGY.md)
-- [Automation Governance](./AUTOMATION_GOVERNANCE.md)
-
----
-
-*Labeling, status, type, and standardization for PRs are handled exclusively by the unified agent and workflow.*
-
-*Built by 🧱 LightSpeedWP with ☕, 🚀, and open-source spirit!*
-[Contributors](https://github.com/lightspeedwp/lsx-demo-theme/graphs/contributors)
+```bash
+node scripts/agents/includes/check-template-labels.js
+node scripts/validation/validate-labeling-configs.cjs
+```


### PR DESCRIPTION
## Summary
- add canonical `docs/GITHUB_PROJECT_OPERATIONS_SPEC.md`
- align branching/issue-fields/label docs to canonical source-of-truth model
- normalise PR template changelog-skip wording to `meta:no-changelog`
- add `.github/projects/active/github-workflow-consolidation-2026-05-28/` with parent/child issue pack and drift report
- create and backfill GitHub issue links into parent/child frontmatter

## Validation
- `npx markdownlint-cli2 "**/*.md"`
- `git diff --check`
- `node scripts/agents/includes/check-template-labels.js`
- `node scripts/validation/validate-labeling-configs.cjs`
- `node scripts/validation/validate-issue-fields.cjs`
- `npm run validate:workflows`
- pre-push `npm test` (hook)

Closes #504
Closes #505
Closes #506
Closes #507
Closes #508
Closes #509
Relates #503
