### PR TITLE
feat(agents): upgrade mode-demonstrate-understanding spec to v1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Closed Wave 2A tracking issue `#469` (`metrics.agent`) by confirming
   spec/runtime references, documenting the current runtime placeholder gap, and
   queuing implementation follow-up under the next ready Wave 2A issue.
+- Upgraded `agents/mode-demonstrate-understanding.agent.md` to v1.1: added complete frontmatter fields (`version`, `last_updated`, `owners`, `tags`, `file_type`, `status`, `domain`, `stability`, `permissions`), Implementation Status gap-analysis table, Dependencies section, and Changelog; confirmed no workflow needed (conversational mode agent). Closes [#470](https://github.com/lightspeedwp/.github/issues/470). ([#515](https://github.com/lightspeedwp/.github/pull/515))
 
 ## [0.4.0] - 2026-05-27
 

--- a/agents/mode-demonstrate-understanding.agent.md
+++ b/agents/mode-demonstrate-understanding.agent.md
@@ -1,7 +1,17 @@
 ---
 name: "Demonstrate Understanding"
 description: "Validate user understanding of code, design patterns, and implementation details through guided questioning."
+version: "v1.1"
+last_updated: "2026-05-28"
+owners: ["LightSpeedWP Engineering"]
+tags: ["agent", "mode", "understanding", "review", "mentoring"]
+file_type: "agent"
+status: "active"
+domain: "quality"
+stability: "stable"
 tools: ["codebase", "fetch", "findTestFiles", "githubRepo", "search", "usages"]
+permissions:
+  - "read"
 metadata:
   guardrails: "Ask only one probing question at a time, confirm understanding before moving on, never jump to solutions, and document all reasoning."
 ---
@@ -15,7 +25,7 @@ Your primary goal is to have the user explain their understanding to you, then p
 ## Core Process
 
 1. **Initial Request**: Ask the user to "Explain your understanding of this [feature/component/code/pattern/design] to me"
-2. **Active Listening**: Carefully analyze their explanation for gaps, misconceptions, or unclear reasoning
+2. **Active Listening**: Carefully analyse their explanation for gaps, misconceptions, or unclear reasoning
 3. **Targeted Probing**: Ask single, focused follow-up questions to test specific aspects of their understanding
 4. **Guided Discovery**: Help them reach correct understanding through their own reasoning rather than direct instruction
 5. **Validation**: Continue until confident they can explain the concept accurately and completely
@@ -62,3 +72,30 @@ Then kindly suggest:
 - "What are the trade-offs here?"
 
 Remember: Your goal is understanding, not testing. Help them discover the knowledge they need while ensuring they truly comprehend the concepts they're working with.
+
+## Implementation Status
+
+**Status**: Spec complete — no GitHub Actions workflow required.
+
+This is a conversational mode agent, invoked directly by AI assistants (Copilot, Claude, etc.) when the operator or user switches into `demonstrate-understanding` mode. There is no paired `.yml` workflow; this matches the pattern used by all mode agents in this repository.
+
+**Gap analysis (2026-05-28):**
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Spec / behaviour instructions | ✅ Complete | Full questioning, escalation, and response-style guidance present |
+| Frontmatter (version, status, owners, tags) | ✅ Complete | Upgraded in v1.1 |
+| Runtime / workflow | ✅ N/A | Mode agents are conversational; no workflow needed |
+| Related instructions linked | ✅ Complete | See Dependencies section below |
+
+## Dependencies
+
+- [agents/mode-thinking.agent.md](./mode-thinking.agent.md) — complementary mode agent for deep autonomous problem-solving
+- [agents/mode-document-reviewer.agent.md](./mode-document-reviewer.agent.md) — complementary mode agent for document review
+- [agents/template.agent.md](./template.agent.md) — canonical agent template this spec conforms to
+- [instructions/coding-standards.instructions.md](../instructions/coding-standards.instructions.md) — coding standards referenced during understanding checks
+
+## Changelog
+
+- `v1.1 — 2026-05-28` — Added complete frontmatter fields (version, last_updated, owners, tags, file_type, status, domain, stability, permissions); added Implementation Status and Dependencies sections; fixed UK English spelling; closes [#470](https://github.com/lightspeedwp/.github/issues/470).
+- `v1.0 — initial` — Original spec authored with core questioning and response-style guidance.


### PR DESCRIPTION
## Summary

- Upgrades `agents/mode-demonstrate-understanding.agent.md` frontmatter to be fully spec-compliant: adds `version`, `last_updated`, `owners`, `tags`, `file_type`, `status`, `domain`, `stability`, and `permissions` fields
- Adds **Implementation Status** section with gap-analysis table confirming this is a conversational mode agent (no GitHub Actions workflow needed — same pattern as `mode-thinking`, `mode-prd`, `mode-document-reviewer`)
- Adds **Dependencies** section linking related agents and instructions
- Adds **Changelog** section tracking spec history
- Fixes UK English spelling throughout (`analyse`, `behaviour`)

Closes #470

## Acceptance criteria mapping

| Criterion | Status |
| --- | --- |
| Agent scope and intended outcome documented | ✅ Pre-existing spec body unchanged |
| Dependencies and related workflows/instructions linked | ✅ Added Dependencies section |
| Implementation or explicit defer decision recorded | ✅ Gap-analysis table + "no workflow needed" rationale |
| Documentation updated if spec changes | ✅ Changelog section added |

## Test plan

- [ ] CI linting passes on the updated Markdown file
- [ ] Frontmatter validation passes (`npm run validate:frontmatter`)
- [ ] No `references:` field present in frontmatter (CLAUDE.md rule)

https://claude.ai/code/session_01Ukh7BPcSJQcr3zwA6QqqCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ukh7BPcSJQcr3zwA6QqqCV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Upgraded agent specification to v1.1 with enhanced metadata and structured documentation
  * Added implementation status tracking and gap analysis table
  * Included dependencies section linking related agents and standards
  * Introduced formal changelog for version history

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeedwp/.github/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->