### PR TITLE
feat(agents): upgrade mode-document-reviewer spec to v1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spec/runtime references, documenting the current runtime placeholder gap, and
   queuing implementation follow-up under the next ready Wave 2A issue.
 - Upgraded `agents/mode-demonstrate-understanding.agent.md` to v1.1: added complete frontmatter fields (`version`, `last_updated`, `owners`, `tags`, `file_type`, `status`, `domain`, `stability`, `permissions`), Implementation Status gap-analysis table, Dependencies section, and Changelog; confirmed no workflow needed (conversational mode agent). Closes [#470](https://github.com/lightspeedwp/.github/issues/470). ([#515](https://github.com/lightspeedwp/.github/pull/515))
+- Upgraded `agents/mode-document-reviewer.agent.md` to v1.1: added complete frontmatter fields (`version`, `last_updated`, `owners`, `tags`, `file_type`, `status`, `domain`, `stability`, `permissions`), Implementation Status gap-analysis table, Dependencies section, and Changelog; confirmed no workflow needed (conversational mode agent). Closes [#471](https://github.com/lightspeedwp/.github/issues/471). ([#516](https://github.com/lightspeedwp/.github/pull/516))
 
 ## [0.4.0] - 2026-05-27
 

--- a/agents/mode-document-reviewer.agent.md
+++ b/agents/mode-document-reviewer.agent.md
@@ -1,6 +1,15 @@
 ---
 name: "Technical Content Evaluator"
 description: "Elite technical content editor and curriculum architect for evaluating technical training materials, documentation, and educational content. Reviews for technical accuracy, pedagogical excellence, content flow, code validation, and ensures A-grade quality standards."
+version: "v1.1"
+last_updated: "2026-05-28"
+owners: ["LightSpeedWP Engineering"]
+tags: ["agent", "mode", "document-review", "editorial", "quality", "education"]
+file_type: "agent"
+status: "active"
+domain: "quality"
+stability: "stable"
+model: "Claude Sonnet 4.5 (copilot)"
 tools:
   [
     "edit",
@@ -12,7 +21,9 @@ tools:
     "todos",
     "runSubagent",
   ]
-model: Claude Sonnet 4.5 (copilot)
+permissions:
+  - "read"
+  - "write"
 metadata:
   guardrails: "Complete the mandatory analysis, compute the Documentation Wrapper Score before responding, and never skip the editorial standards described in the spec."
 ---
@@ -638,3 +649,31 @@ After identifying problems, always provide clear paths forward:
 ---
 
 **You are the final quality gate before content reaches learners. Your standards are uncompromising because education deserves nothing less than excellence. Be honest about what content actually IS, not what it claims to be.**
+
+## Implementation Status
+
+**Status**: Spec complete — no GitHub Actions workflow required.
+
+This is a conversational mode agent, invoked directly by AI assistants (Copilot, Claude, etc.) when the operator or user switches into `document-reviewer` mode. There is no paired `.yml` workflow; this matches the pattern used by all mode agents in this repository (`mode-thinking`, `mode-demonstrate-understanding`, `mode-prd`).
+
+**Gap analysis (2026-05-28):**
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Spec / behaviour instructions | ✅ Complete | Comprehensive editorial standards, grading rubric, output format, and engagement style documented |
+| Frontmatter (version, status, owners, tags) | ✅ Complete | Upgraded in v1.1 |
+| Runtime / workflow | ✅ N/A | Mode agents are conversational; no workflow needed |
+| Related instructions linked | ✅ Complete | See Dependencies section below |
+
+## Dependencies
+
+- [agents/mode-thinking.agent.md](./mode-thinking.agent.md) — complementary mode agent for deep autonomous problem-solving
+- [agents/mode-demonstrate-understanding.agent.md](./mode-demonstrate-understanding.agent.md) — complementary mode agent for guided understanding validation
+- [agents/mode-prd.agent.md](./mode-prd.agent.md) — complementary mode agent for product requirements documentation
+- [agents/template.agent.md](./template.agent.md) — canonical agent template this spec conforms to
+- [instructions/coding-standards.instructions.md](../instructions/coding-standards.instructions.md) — coding standards applied during technical content review
+
+## Changelog
+
+- `v1.1 — 2026-05-28` — Added complete frontmatter fields (version, last_updated, owners, tags, file_type, status, domain, stability, permissions); added Implementation Status and Dependencies sections; closes [#471](https://github.com/lightspeedwp/.github/issues/471).
+- `v1.0 — initial` — Original spec authored with comprehensive editorial standards, grading rubric, and engagement style guidelines.


### PR DESCRIPTION
## Summary

- Upgrades `agents/mode-document-reviewer.agent.md` frontmatter to be fully spec-compliant: adds `version`, `last_updated`, `owners`, `tags`, `file_type`, `status`, `domain`, `stability`, and `permissions` fields
- Adds **Implementation Status** section with gap-analysis table confirming this is a conversational mode agent (no GitHub Actions workflow needed)
- Adds **Dependencies** section linking related mode agents and instructions
- Adds **Changelog** section tracking spec history
- Updates `CHANGELOG.md` with entry for this change

Closes #471

## Acceptance criteria mapping

| Criterion | Status |
| --- | --- |
| Agent scope and intended outcome documented | ✅ Pre-existing spec body is comprehensive (editorial standards, grading rubric, output format) |
| Dependencies and related workflows/instructions linked | ✅ Added Dependencies section |
| Implementation or explicit defer decision recorded | ✅ Gap-analysis table + "no workflow needed" rationale |
| Documentation updated if spec changes | ✅ Changelog section added |

## Test plan

- [ ] CI linting passes on the updated Markdown file
- [ ] Frontmatter validation passes (`npm run validate:frontmatter`)
- [ ] No `references:` field present in frontmatter (CLAUDE.md rule)

https://claude.ai/code/session_01Ukh7BPcSJQcr3zwA6QqqCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ukh7BPcSJQcr3zwA6QqqCV)_