### PR TITLE
Issue #535: Complete plugin-structure.instructions.md migration

### DIFF
--- a/instructions/plugin-structure.instructions.md
+++ b/instructions/plugin-structure.instructions.md
@@ -1,5 +1,7 @@
 ---
+title: "WordPress Plugin Structure"
 description: "WordPress block plugin structure conventions for all LightSpeed plugins: directory layout, block.json, asset enqueueing, security, and i18n."
+category: "Documentation"
 applyTo: "**"
 file_type: "instructions"
 version: "v1.0"


### PR DESCRIPTION
## Summary

Completes Issue #535 (Migration of plugin-structure.instructions.md from `.github/instructions/` to top-level `instructions/` folder).

### Changes

1. **Added missing frontmatter fields** to `instructions/plugin-structure.instructions.md`:
   - Added `title: "WordPress Plugin Structure"`
   - Added `category: "Documentation"`
   - Ensures full frontmatter validation compliance per CLAUDE.md standards

### Migration Status

- ✅ File moved to `instructions/plugin-structure.instructions.md` (already completed)
- ✅ All references updated in main docs (`CLAUDE.md`, `.github/README.md`)
- ✅ Frontmatter now includes all required fields (`title`, `category`, `description`, `file_type`, `version`, `last_updated`, `owners`, `tags`, `domain`, `stability`)
- ✅ File lints successfully
- ✅ Migration follows CLAUDE.md guidelines for portable reusable assets

### Related Issue

Closes #535

---
_Generated by [Claude Code](https://claude.ai/code/session_016NcEdvkmrV1EbFNozPGeGX)_