### PR TITLE
Issue #535: Add missing title and category frontmatter fields to plugin-structure.instructions.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ title: "Changelog"
 description: "All notable changes to this project, formatted per Keep a Changelog 1.1.0 and Semantic Versioning"
 file_type: "documentation"
 category: "Governance"
-version: "1.0.0"
+version: "1.0.1"
 last_updated: "2026-05-28"
 owners: ["Engineering Team"]
 tags: ["changelog", "versioning", "releases", "governance"]
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Quarterly health reports with recommendations
   - CI/CD integration patterns and metric collection
   - Foundation for long-term automation roadmap (Waves 5-7) ([#536](https://github.com/lightspeedwp/.github/pull/536))
+
+### Fixed
+
+- **Plugin Structure Instructions Frontmatter** — Added missing `title` and `category` fields to `instructions/plugin-structure.instructions.md` to meet frontmatter schema requirements ([#535](https://github.com/lightspeedwp/.github/pull/547))
 
 ### Changed
 

--- a/instructions/plugin-structure.instructions.md
+++ b/instructions/plugin-structure.instructions.md
@@ -1,9 +1,11 @@
 ---
+title: "WordPress Plugin Structure"
 description: "WordPress block plugin structure conventions for all LightSpeed plugins: directory layout, block.json, asset enqueueing, security, and i18n."
+category: "Documentation"
 applyTo: "**"
 file_type: "instructions"
-version: "v1.0"
-last_updated: "2026-05-20"
+version: "v1.1"
+last_updated: "2026-05-28"
 owners: ["LightSpeed Team"]
 tags: ["wordpress", "plugin", "blocks", "block-json", "structure", "php", "i18n"]
 domain: "plugin-hardening"


### PR DESCRIPTION
## Description

Adds missing frontmatter fields to `instructions/plugin-structure.instructions.md` as required for issue #535, plus changelog documentation.

### Changes
- Add `title: "WordPress Plugin Structure"` to frontmatter
- Add `category: "Documentation"` to frontmatter
- Update `last_updated` from 2026-05-20 to 2026-05-28
- Bump `version` from v1.0 to v1.1
- Document the fix in CHANGELOG.md (Unreleased > Fixed section)

These changes ensure the file meets the frontmatter schema requirements for portable instruction files in the LightSpeed repository.

### Related Issue
Closes #535