### PR TITLE
fix(mergify): use actual check context names for Dependabot rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,9 +4,9 @@ pull_request_rules:
       - author~=^(dependabot\[bot\]|app/dependabot)$
       - base=develop
       - label=area:dependencies
-      - check-success=CI / check
-      - check-success=CI / lint
-      - check-success=changelog-validate / validate
+      - check-success=check
+      - check-success=lint
+      - check-success=validate
       - -draft
       - -conflict
     actions:
@@ -19,9 +19,9 @@ pull_request_rules:
       - base=develop
       - label=area:dependencies
       - label=meta:dependabot-security
-      - check-success=CI / check
-      - check-success=CI / lint
-      - check-success=changelog-validate / validate
+      - check-success=check
+      - check-success=lint
+      - check-success=validate
       - -draft
       - -conflict
     actions:


### PR DESCRIPTION
## Summary\n- update Mergify check-success conditions to match actual check run names used on Dependabot PRs\n- replace prefixed context strings with check, lint, and validate\n\n## Why\nDependabot PRs #532 and #533 passed checks but remained open because Mergify conditions referenced non-matching context names.\n\n## Validation\n- npm run lint:yaml\n- npm run test:js (pre-commit)\n