### PR TITLE
fix: correct Dependabot author in Mergify rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: Auto-merge Dependabot dependency updates on develop
     conditions:
-      - author=dependabot
+      - author=dependabot[bot]
       - base=develop
       - label=area:dependencies
       - check-success=check
@@ -14,7 +14,7 @@ pull_request_rules:
 
   - name: Auto-merge Dependabot security updates on develop
     conditions:
-      - author=dependabot
+      - author=dependabot[bot]
       - base=develop
       - label=area:dependencies
       - label=meta:dependabot-security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mergify Dependabot Auto-merge Rules** — Corrected Mergify configuration to automatically merge Dependabot PRs by fixing the author condition from `author=dependabot` to `author=dependabot[bot]` to match GitHub's actual Dependabot bot account name ([#573](https://github.com/lightspeedwp/.github/issues/573))
+
 ### Added
 
 - **WCEU 2026 Validation Scripts (Bash-to-JavaScript Migration)** — Completed migration of WCEU validation scripts from Bash to JavaScript with improvements:


### PR DESCRIPTION
## Summary

Fix Mergify auto-merge rules for Dependabot PRs by correcting the author condition.

## Problem

The Mergify configuration had `author=dependabot` but GitHub's Dependabot bot account is registered as `dependabot[bot]`, causing the auto-merge rules to never match.

## Solution

Updated both auto-merge rules (dependency updates and security updates) to use the correct author: `author=dependabot[bot]`

## Testing

This will be validated once the Dependabot PRs (#532, #533) are processed by Mergify with the corrected rules.

---
_Generated by [Claude Code](https://claude.ai/code/session_015QNP4SGYZTmRmXNQachTTf)_