### PR TITLE
fix: inject unreleased section after changelog version roll (#586)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Release Agent: Branch Push Upstream Tracking** — Fixed release agent to use `git push -u origin` when pushing release branches, ensuring proper upstream tracking for subsequent PR creation ([#585](https://github.com/lightspeedwp/.github/issues/585))
+- **Release Agent: [Unreleased] Section Recreation** — Fixed release agent to inject new `[Unreleased]` section after rolling version, ensuring changelog is ready for next contribution cycle ([#586](https://github.com/lightspeedwp/.github/issues/586))
 - **Mergify Dependabot Auto-merge Rules** — Corrected Mergify configuration to automatically merge Dependabot PRs by fixing the author condition from `author=dependabot` to `author=dependabot[bot]` to match GitHub's actual Dependabot bot account name ([#573](https://github.com/lightspeedwp/.github/issues/573))
 - **WCEU 2026 Branch Name References** — Updated references in `FINAL_REVIEW_CHECKLIST.md` and `PHASE1_COMPLETION_REPORT.md` from old branch name `claude/charming-goldberg-Pqc69` to correct branch `claude/affectionate-bohr-AX2jS`
 

--- a/scripts/agents/release.agent.js
+++ b/scripts/agents/release.agent.js
@@ -496,21 +496,57 @@ function updateChangelog(newVersion, options = {}) {
   const content = fs.readFileSync(changelogPath, "utf8");
   const today = new Date().toISOString().split("T")[0];
 
+  const unreleasedTemplate = `## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+### Security
+
+### Documentation
+
+### Performance
+
+`;
+
   // Replace [Unreleased] - DD-MM-YYYY with [newVersion] - YYYY-MM-DD
-  const updatedContent = content.replace(
+  let updatedContent = content.replace(
     /^## \[Unreleased\] - (?:DD-MM-YYYY|YYYY-MM-DD|\d{4}-\d{2}-\d{2})$/m,
     `## [${newVersion}] - ${today}`,
   );
 
+  // Inject new Unreleased section at the top (after any frontmatter)
+  const frontmatterMatch = updatedContent.match(/^---\n[\s\S]*?\n---\n/);
+  if (frontmatterMatch) {
+    const endOfFrontmatter = frontmatterMatch[0].length;
+    updatedContent =
+      updatedContent.slice(0, endOfFrontmatter) +
+      unreleasedTemplate +
+      updatedContent.slice(endOfFrontmatter);
+  } else {
+    updatedContent = unreleasedTemplate + updatedContent;
+  }
+
   if (dryRun) {
     console.log(
       `[DRY-RUN] Would update CHANGELOG.md Unreleased section to [${newVersion}] - ${today}`,
+    );
+    console.log(
+      `[DRY-RUN] Would inject new [Unreleased] section for next cycle`,
     );
     return;
   }
 
   fs.writeFileSync(changelogPath, updatedContent, "utf8");
   console.log(`✓ CHANGELOG updated with version ${newVersion}`);
+  console.log(`✓ New [Unreleased] section injected for next cycle`);
 }
 
 /**


### PR DESCRIPTION
## Fix: Inject [Unreleased] section after changelog version roll

**Issue**: #586 — Release Agent: [Unreleased] section not recreated after release

### Problem
After rolling `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD` in CHANGELOG.md during release, the new Unreleased section for the next cycle is never added back. This causes:
- Changelog validation failures (no unreleased changes found)
- Contributors can't add entries until manually fixed
- Breaks next release cycle

### Solution
Modified `updateChangelog()` function to inject a new `[Unreleased]` section immediately after rolling the version header. The new section includes all standard subsections (Added, Changed, Fixed, Deprecated, Removed, Security, Documentation, Performance).

### Changes
- Modified `scripts/agents/release.agent.js` updateChangelog() function (line 487-514)
- Added unreleasedTemplate with all standard subsections
- Inject new section after frontmatter (if present) or at top of file
- Updated dry-run logging to show both operations

### Testing
✅ Release agent tests: 24 passed

### Validation Steps
1. Changelog has `[Unreleased]` section after release
2. New section includes all subsections
3. Formatting is correct (not truncated/mangled)
4. Validation passes: `node scripts/validation/validate-changelog.cjs CHANGELOG.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_012exLuG2NpnB5eqGG3bSxdn)_