### PR TITLE
feat: Migrate quick_check_skill.sh to JavaScript (validateSkillStructure)

### DIFF
--- a/scripts/skill-utils/__tests__/validateSkillStructure.test.js
+++ b/scripts/skill-utils/__tests__/validateSkillStructure.test.js
@@ -1,0 +1,274 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { validateSkillStructure } = require("../validateSkillStructure");
+
+describe("validateSkillStructure", () => {
+  let tempDir;
+  let skillDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "validate-skill-"));
+    skillDir = path.join(tempDir, "test-skill");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.mkdirSync(path.join(skillDir, "agents"), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true });
+    }
+  });
+
+  it("should throw error if skill directory does not exist", () => {
+    const nonexistentDir = path.join(tempDir, "nonexistent");
+    expect(() => validateSkillStructure(nonexistentDir)).toThrow(
+      "Skill directory not found",
+    );
+  });
+
+  it("should throw error if SKILL.md not found", () => {
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "SKILL.md not found",
+    );
+  });
+
+  it("should throw error if agents/openai.yaml not found", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: test-skill\ndescription: Test\n---\n",
+    );
+
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "agents/openai.yaml not found",
+    );
+  });
+
+  it("should throw error if SKILL.md does not start with frontmatter", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(skillMd, "# No frontmatter\nTest content");
+    fs.writeFileSync(path.join(skillDir, "agents/openai.yaml"), "");
+
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "SKILL.md must start with YAML frontmatter",
+    );
+  });
+
+  it("should throw error if name is not lowercase hyphen-case", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: TestSkill\ndescription: Test\n---\nContent",
+    );
+    fs.writeFileSync(path.join(skillDir, "agents/openai.yaml"), "");
+
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "frontmatter name must be lowercase hyphen-case",
+    );
+  });
+
+  it("should throw error if description is missing", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(skillMd, "---\nname: test-skill\n---\nContent");
+    fs.writeFileSync(path.join(skillDir, "agents/openai.yaml"), "");
+
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "frontmatter description missing",
+    );
+  });
+
+  it("should throw error if name does not match folder name", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: different-skill\ndescription: Test\n---\nContent",
+    );
+    fs.writeFileSync(path.join(skillDir, "agents/openai.yaml"), "");
+
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "frontmatter name must match folder name",
+    );
+  });
+
+  it("should throw error if __pycache__ directory exists", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: test-skill\ndescription: Test\n---\nContent",
+    );
+    fs.writeFileSync(path.join(skillDir, "agents/openai.yaml"), "");
+    fs.mkdirSync(path.join(skillDir, "__pycache__"), { recursive: true });
+
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "package noise found",
+    );
+  });
+
+  it("should throw error if node_modules directory exists", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: test-skill\ndescription: Test\n---\nContent",
+    );
+    fs.writeFileSync(path.join(skillDir, "agents/openai.yaml"), "");
+    fs.mkdirSync(path.join(skillDir, "node_modules"), { recursive: true });
+
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "package noise found",
+    );
+  });
+
+  it("should throw error if .DS_Store file exists", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: test-skill\ndescription: Test\n---\nContent",
+    );
+    fs.writeFileSync(path.join(skillDir, "agents/openai.yaml"), "");
+    fs.writeFileSync(path.join(skillDir, ".DS_Store"), "");
+
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "package noise found",
+    );
+  });
+
+  it("should return valid object for valid skill structure", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: test-skill\ndescription: A test skill\n---\n# Overview\nTest content",
+    );
+    fs.writeFileSync(
+      path.join(skillDir, "agents/openai.yaml"),
+      "config: value",
+    );
+
+    const result = validateSkillStructure(skillDir);
+    expect(result.valid).toBe(true);
+    expect(result.name).toBe("test-skill");
+    expect(result.folderName).toBe("test-skill");
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("should detect placeholder text when checkPlaceholders is true", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: test-skill\ndescription: A test skill\n---\n# Overview\nTODO: implement this",
+    );
+    fs.writeFileSync(
+      path.join(skillDir, "agents/openai.yaml"),
+      "config: value",
+    );
+
+    const result = validateSkillStructure(skillDir, {
+      checkPlaceholders: true,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain("possible placeholder text found");
+  });
+
+  it("should not detect placeholder text when checkPlaceholders is false", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: test-skill\ndescription: A test skill\n---\n# Overview\nTODO: implement this",
+    );
+    fs.writeFileSync(
+      path.join(skillDir, "agents/openai.yaml"),
+      "config: value",
+    );
+
+    const result = validateSkillStructure(skillDir, {
+      checkPlaceholders: false,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("should detect placeholder text containing 'Replace with'", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: test-skill\ndescription: A test skill\n---\n# Overview\nReplace with actual content",
+    );
+    fs.writeFileSync(
+      path.join(skillDir, "agents/openai.yaml"),
+      "config: value",
+    );
+
+    const result = validateSkillStructure(skillDir, {
+      checkPlaceholders: true,
+    });
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("should detect placeholder text containing 'placeholder'", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: test-skill\ndescription: A test skill\n---\n# Overview\nThis is a placeholder section",
+    );
+    fs.writeFileSync(
+      path.join(skillDir, "agents/openai.yaml"),
+      "config: value",
+    );
+
+    const result = validateSkillStructure(skillDir, {
+      checkPlaceholders: true,
+    });
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("should allow hyphens in skill name", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    const skillName = "my-complex-skill-name";
+    fs.writeFileSync(
+      skillMd,
+      `---\nname: ${skillName}\ndescription: A test skill\n---\nContent`,
+    );
+    fs.writeFileSync(path.join(skillDir, "agents/openai.yaml"), "");
+
+    // Create directory with matching name
+    const skillDir2 = path.join(tempDir, skillName);
+    fs.mkdirSync(skillDir2, { recursive: true });
+    fs.mkdirSync(path.join(skillDir2, "agents"), { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir2, "SKILL.md"),
+      `---\nname: ${skillName}\ndescription: A test skill\n---\nContent`,
+    );
+    fs.writeFileSync(path.join(skillDir2, "agents/openai.yaml"), "");
+
+    const result = validateSkillStructure(skillDir2);
+    expect(result.valid).toBe(true);
+    expect(result.name).toBe(skillName);
+  });
+
+  it("should reject name starting with a number", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: 123-skill\ndescription: A test skill\n---\nContent",
+    );
+    fs.writeFileSync(path.join(skillDir, "agents/openai.yaml"), "");
+
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "frontmatter name must be lowercase hyphen-case",
+    );
+  });
+
+  it("should reject name with uppercase letters", () => {
+    const skillMd = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillMd,
+      "---\nname: test-Skill\ndescription: A test skill\n---\nContent",
+    );
+    fs.writeFileSync(path.join(skillDir, "agents/openai.yaml"), "");
+
+    expect(() => validateSkillStructure(skillDir)).toThrow(
+      "frontmatter name must be lowercase hyphen-case",
+    );
+  });
+});

--- a/scripts/skill-utils/validateSkillStructure.js
+++ b/scripts/skill-utils/validateSkillStructure.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const path = require("path");
-const { execSync } = require("child_process");
 
 function validateSkillStructure(skillDir, options = {}) {
   const { checkPlaceholders = true } = options;
@@ -19,7 +18,7 @@ function validateSkillStructure(skillDir, options = {}) {
     throw new Error("agents/openai.yaml not found");
   }
 
-  const skillContent = fs.readFileSync(skillMd, "utf8");
+  const skillContent = fs.readFileSync(skillMd, "utf8").replace(/\r\n/g, "\n");
   const firstLine = skillContent.split("\n")[0];
   if (firstLine !== "---") {
     throw new Error("SKILL.md must start with YAML frontmatter");
@@ -45,57 +44,72 @@ function validateSkillStructure(skillDir, options = {}) {
     throw new Error("frontmatter name must match folder name");
   }
 
-  const noisePatterns = [
-    "__MACOSX",
-    ".DS_Store",
-    "*.pyc",
-    "__pycache__",
-    "node_modules",
+  const warnings = [];
+  const excludePatterns = [
+    "quick_check_skill.sh",
+    "validateSkillStructure.js",
+    "packageSkillZip.js",
   ];
 
-  for (const pattern of noisePatterns) {
-    try {
-      const cmd = `find "${skillDir}" -name "${pattern}" 2>/dev/null | head -1`;
-      const result = execSync(cmd, { encoding: "utf8", stdio: "pipe" }).trim();
-      if (result) {
+  function traverse(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      const entryName = entry.name;
+
+      if (
+        entryName === "__MACOSX" ||
+        entryName === ".DS_Store" ||
+        entryName === "__pycache__" ||
+        entryName === "node_modules" ||
+        entryName.endsWith(".pyc")
+      ) {
         throw new Error("package noise found");
       }
-    } catch (error) {
-      if (error.message === "package noise found") {
-        throw error;
+
+      if (entry.isDirectory()) {
+        traverse(fullPath);
+      } else if (entry.isFile()) {
+        if (excludePatterns.includes(entryName)) {
+          continue;
+        }
+        if (checkPlaceholders) {
+          try {
+            const content = fs.readFileSync(fullPath, "utf8");
+            const lines = content.split(/\r?\n/);
+            for (let i = 0; i < lines.length; i++) {
+              const line = lines[i];
+              if (
+                line.includes("TODO") ||
+                line.includes("placeholder") ||
+                line.includes("Replace with")
+              ) {
+                warnings.push(fullPath + ":" + line.trim());
+              }
+            }
+          } catch {
+            // Ignore binary files or read errors
+          }
+        }
       }
     }
   }
 
-  const warnings = [];
-  if (checkPlaceholders) {
-    const excludePatterns = [
-      "quick_check_skill.sh",
-      "validateSkillStructure.js",
-    ];
-    try {
-      const excludeArgs = excludePatterns
-        .map((p) => `--exclude="${p}"`)
-        .join(" ");
-      const cmd = `grep -r "TODO\\|placeholder\\|Replace with" "${skillDir}" ${excludeArgs} 2>/dev/null || true`;
-      const hits = execSync(cmd, {
-        encoding: "utf8",
-        shell: "/bin/bash",
-      }).trim();
-      if (hits) {
-        const lines = hits.split("\n").slice(0, 20);
-        warnings.push("possible placeholder text found:\n" + lines.join("\n"));
-      }
-    } catch {
-      // Ignore grep errors
-    }
+  traverse(skillDir);
+
+  const formattedWarnings = [];
+  if (warnings.length > 0) {
+    const lines = warnings.slice(0, 20);
+    formattedWarnings.push(
+      "possible placeholder text found:\n" + lines.join("\n"),
+    );
   }
 
   return {
     valid: true,
     name,
     folderName,
-    warnings,
+    warnings: formattedWarnings,
   };
 }
 

--- a/scripts/skill-utils/validateSkillStructure.js
+++ b/scripts/skill-utils/validateSkillStructure.js
@@ -1,0 +1,102 @@
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+function validateSkillStructure(skillDir, options = {}) {
+  const { checkPlaceholders = true } = options;
+
+  if (!fs.existsSync(skillDir)) {
+    throw new Error("Skill directory not found");
+  }
+
+  const skillMd = path.join(skillDir, "SKILL.md");
+  if (!fs.existsSync(skillMd)) {
+    throw new Error("SKILL.md not found");
+  }
+
+  const agentYaml = path.join(skillDir, "agents/openai.yaml");
+  if (!fs.existsSync(agentYaml)) {
+    throw new Error("agents/openai.yaml not found");
+  }
+
+  const skillContent = fs.readFileSync(skillMd, "utf8");
+  const firstLine = skillContent.split("\n")[0];
+  if (firstLine !== "---") {
+    throw new Error("SKILL.md must start with YAML frontmatter");
+  }
+
+  const nameMatch = skillContent.match(/^name: [a-z][a-z0-9-]*$/m);
+  if (!nameMatch) {
+    throw new Error("frontmatter name must be lowercase hyphen-case");
+  }
+
+  if (!skillContent.match(/^description: /m)) {
+    throw new Error("frontmatter description missing");
+  }
+
+  const nameLineMatch = skillContent.match(/^name: (.+)$/m);
+  if (!nameLineMatch) {
+    throw new Error("Could not parse name from SKILL.md");
+  }
+
+  const name = nameLineMatch[1].trim();
+  const folderName = path.basename(skillDir);
+  if (name !== folderName) {
+    throw new Error("frontmatter name must match folder name");
+  }
+
+  const noisePatterns = [
+    "__MACOSX",
+    ".DS_Store",
+    "*.pyc",
+    "__pycache__",
+    "node_modules",
+  ];
+
+  for (const pattern of noisePatterns) {
+    try {
+      const cmd = `find "${skillDir}" -name "${pattern}" 2>/dev/null | head -1`;
+      const result = execSync(cmd, { encoding: "utf8", stdio: "pipe" }).trim();
+      if (result) {
+        throw new Error("package noise found");
+      }
+    } catch (error) {
+      if (error.message === "package noise found") {
+        throw error;
+      }
+    }
+  }
+
+  const warnings = [];
+  if (checkPlaceholders) {
+    const excludePatterns = [
+      "quick_check_skill.sh",
+      "validateSkillStructure.js",
+    ];
+    try {
+      const excludeArgs = excludePatterns
+        .map((p) => `--exclude="${p}"`)
+        .join(" ");
+      const cmd = `grep -r "TODO\\|placeholder\\|Replace with" "${skillDir}" ${excludeArgs} 2>/dev/null || true`;
+      const hits = execSync(cmd, {
+        encoding: "utf8",
+        shell: "/bin/bash",
+      }).trim();
+      if (hits) {
+        const lines = hits.split("\n").slice(0, 20);
+        warnings.push("possible placeholder text found:\n" + lines.join("\n"));
+      }
+    } catch {
+      // Ignore grep errors
+    }
+  }
+
+  return {
+    valid: true,
+    name,
+    folderName,
+    warnings,
+  };
+}
+
+module.exports = { validateSkillStructure };


### PR DESCRIPTION
## Summary

Migrated `quick_check_skill.sh` to a reusable JavaScript module `validateSkillStructure.js` with comprehensive Jest test coverage. This is part of the broader initiative to eliminate all shell scripts.

## Changes

- **New Module**: `scripts/skill-utils/validateSkillStructure.js`
  - Validates skill directory structure
  - Checks SKILL.md with YAML frontmatter
  - Verifies agents/openai.yaml presence
  - Validates name format (lowercase hyphen-case starting with letter)
  - Detects package noise (__pycache__, node_modules, .DS_Store, etc.)
  - Optional placeholder text detection (TODO, placeholder, Replace with)
  - CommonJS exports for Jest compatibility

- **Test Suite**: `scripts/skill-utils/__tests__/validateSkillStructure.test.js`
  - 18 comprehensive tests covering all validation scenarios
  - Tests for: directory structure, frontmatter, name format, folder matching, noise detection, placeholder detection
  - Full edge case coverage

## Features Migrated

- ✅ SKILL.md presence and frontmatter validation
- ✅ agents/openai.yaml presence check
- ✅ Name format validation (must be lowercase hyphen-case, starting with letter)
- ✅ Name-to-folder matching
- ✅ Package noise detection (multiple patterns)
- ✅ Optional placeholder text detection
- ✅ Comprehensive error messages
- ✅ Return structured validation result

## Test Results

```
PASS scripts/skill-utils/__tests__/validateSkillStructure.test.js
  validateSkillStructure (18 tests)
  - should throw error if skill directory does not exist
  - should throw error if SKILL.md not found
  - should throw error if agents/openai.yaml not found
  - should throw error if SKILL.md does not start with frontmatter
  - should throw error if name is not lowercase hyphen-case
  - should throw error if description is missing
  - should throw error if name does not match folder name
  - should throw error if __pycache__ directory exists
  - should throw error if node_modules directory exists
  - should throw error if .DS_Store file exists
  - should return valid object for valid skill structure
  - should detect placeholder text when checkPlaceholders is true
  - should not detect placeholder text when checkPlaceholders is false
  - should detect placeholder text containing 'Replace with'
  - should detect placeholder text containing 'placeholder'
  - should allow hyphens in skill name
  - should reject name starting with a number
  - should reject name with uppercase letters

  Tests: 18 passed, 18 total
```

## Replaces

This module replaces two identical `quick_check_skill.sh` scripts:
- `skills/design-md-agent/figma-wordpress-skill-creator/scripts/quick_check_skill.sh`
- `skills/design-md-agent/wordpress-plugin-packaging-review/scripts/quick_check_skill.sh`

## Related Issues

Closes #613 - Part of #616 (Epic: Migrate All Bash Scripts to JavaScript)

## Test Plan

- [x] Jest tests pass (18/18)
- [x] All validation scenarios covered
- [x] Edge cases tested (hyphens, numbers, uppercase)
- [x] Placeholder detection tested with various patterns
- [x] Package noise detection verified
- [x] CommonJS compatibility confirmed

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1BeR5Rc2vNYaMQtgw6ERd)_