### PR TITLE
docs: add WCEU 2026 talk asset pack

### DIFF
--- a/wceu-2026/README.md
+++ b/wceu-2026/README.md
@@ -1,0 +1,24 @@
+---
+title: "WCEU 2026 Talk Asset Pack"
+description: "Working assets for the WordCamp Europe 2026 talk on evolving lightspeedwp/.github into an installable AI-ops and governance plugin platform."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# WCEU 2026 Talk Asset Pack
+
+This folder contains the planning, research, and content assets for a mini website and conference talk:
+
+- `talk-outline-25min.md` - main 25-minute narrative and timing.
+- `slides/` - one reference file per slide.
+- `references/` - repository-grounded source index and evidence map.
+- `notebooklm/` - prompts and ingestion instructions for NotebookLM.
+- `website/` - mini website information architecture and content model.
+
+## Current talk direction
+
+The talk starts with a central `.github` repository pattern, then explains the pivot to installable plugin packs for AI coding tools (Copilot, Claude Code, Codex, Gemini) while preserving governance and quality controls.
+
+## Acknowledgements
+
+This work is inspired by the open sharing in `github/awesome-copilot`, which has been incredibly useful for agent, instruction, and skill design patterns.

--- a/wceu-2026/notebooklm/deep-research-prompt.md
+++ b/wceu-2026/notebooklm/deep-research-prompt.md
@@ -1,0 +1,68 @@
+---
+title: "NotebookLM Deep Research Prompt"
+description: "Prompt for NotebookLM to analyse the talk direction using only lightspeedwp/.github files and this wceu-2026 asset pack."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# NotebookLM Deep Research Prompt
+
+Copy and paste the prompt below into NotebookLM after adding only allowed sources.
+
+## Allowed sources
+
+Use only files from this repository (`lightspeedwp/.github`) plus files under `wceu-2026/`.
+
+Do not use web links, external repos, or prior memory.
+
+## Prompt
+
+You are a research editor preparing a conference mini-site and speaker pack.
+
+Objective:
+Produce a deeply researched, evidence-backed content set for a 25-minute WordCamp Europe talk that explains the evolution of `lightspeedwp/.github` from a central governance repo into installable plugin packs for AI coding tools.
+
+Critical constraints:
+
+1. Only use evidence from files in `lightspeedwp/.github`.
+2. Every claim must map to one or more repository files.
+3. Flag any claim that cannot be supported by repository evidence.
+4. Keep recommendations practical for WordPress agencies and product teams.
+5. Include explicit acknowledgement that `github/awesome-copilot` was inspirational.
+
+Deliverables:
+
+1. A refined narrative arc with 3 act structure for 25 minutes.
+2. Slide-by-slide evidence table (20 slides):
+   - slide objective
+   - key message
+   - supporting repository files
+   - risky or weak claims to avoid
+3. A mini-site content map:
+   - homepage (talk summary)
+   - problem page
+   - architecture page
+   - plugin-pack pivot page
+   - outcomes page
+   - adoption playbook page
+4. A source-backed FAQ (minimum 15 questions).
+5. A "myths vs reality" section about `.github` inheritance and governance limits.
+6. A speaker notes section with:
+   - likely audience objections
+   - concise responses grounded in repo evidence
+   - one practical example for agency owners
+   - one practical example for senior engineers
+7. A repository-safe references section listing only internal file paths.
+
+Output format:
+
+- Start with an executive summary.
+- Then provide the six deliverables in order.
+- Use bullet points and short sections.
+- Include confidence level (high/medium/low) per major claim.
+
+Quality bar:
+
+- Prefer direct evidence over interpretation.
+- Distinguish "implemented now" vs "roadmap/in progress".
+- Make trade-offs explicit (control vs flexibility, standardisation vs autonomy).

--- a/wceu-2026/notebooklm/source-ingestion-checklist.md
+++ b/wceu-2026/notebooklm/source-ingestion-checklist.md
@@ -1,0 +1,42 @@
+---
+title: "NotebookLM Source Ingestion Checklist"
+description: "Checklist to ensure NotebookLM only ingests approved repository sources for this talk."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# NotebookLM Source Ingestion Checklist
+
+## Rule
+
+Only ingest files from `lightspeedwp/.github` and `wceu-2026/`.
+
+## Core sources to add first
+
+- `wceu-2026/talk-outline-25min.md`
+- `wceu-2026/references/repo-source-index.md`
+- `wceu-2026/slides/` (all files)
+- `README.md`
+- `AGENTS.md`
+- `plugins/README.md`
+- `plugins/PLUGIN_MANIFEST.json`
+- `plugins/lightspeed-github-ops/README.md`
+- `docs/PLUGIN_PACK_ROADMAP.md`
+- `docs/PLUGIN_INSTALLATION_GUIDE.md`
+
+## Extended sources for deeper analysis
+
+- `.github/labels.yml`
+- `.github/labeler.yml`
+- `.github/issue-types.yml`
+- `docs/AUTOMATION_GOVERNANCE.md`
+- `docs/RELEASE_PROCESS.md`
+- `docs/WORKFLOWS.md`
+- `docs/METRICS.md`
+- `skills/SKILL_REGISTRY.json`
+
+## Exclusion checklist
+
+- No external websites
+- No files from other repositories
+- No speculative claims without file evidence

--- a/wceu-2026/references/repo-source-index.md
+++ b/wceu-2026/references/repo-source-index.md
@@ -1,0 +1,62 @@
+---
+title: "Repo Source Index"
+description: "Curated source index for talk claims. Only references files inside lightspeedwp/.github."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Repo Source Index
+
+Use this file as the authoritative source inventory for slide writing and NotebookLM ingestion.
+
+## Core positioning
+
+- `README.md` - repository purpose, architecture, and control-plane framing.
+- `AGENTS.md` - global AI rules and operating standards.
+- `CLAUDE.md` - repository boundaries and practical conventions.
+
+## Governance and standards
+
+- `instructions/coding-standards.instructions.md`
+- `instructions/file-organisation.instructions.md`
+- `instructions/labeling.instructions.md`
+- `instructions/spec-driven-workflow.instructions.md`
+- `docs/AUTOMATION_GOVERNANCE.md`
+
+## Labels, templates, and triage
+
+- `.github/labels.yml`
+- `.github/labeler.yml`
+- `.github/issue-types.yml`
+- `.github/ISSUE_TEMPLATE/`
+- `.github/PULL_REQUEST_TEMPLATE/`
+- `docs/ISSUE_TYPES.md`
+- `docs/LABEL_STRATEGY.md`
+
+## Plugin-pack pivot
+
+- `plugins/README.md`
+- `plugins/PLUGIN_MANIFEST.json`
+- `plugins/lightspeed-github-ops/README.md`
+- `docs/PLUGIN_PACK_ROADMAP.md`
+- `docs/PLUGIN_INSTALLATION_GUIDE.md`
+
+## AI assets and portability
+
+- `ai/agents.md`
+- `ai/RUNNERS.md`
+- `skills/SKILL_REGISTRY.json`
+- `skills/README.md`
+- `agents/agent.md`
+
+## Release, quality, and reporting
+
+- `docs/RELEASE_PROCESS.md`
+- `docs/TESTING.md`
+- `docs/METRICS.md`
+- `docs/WORKFLOWS.md`
+- `.github/workflows/`
+
+## Acknowledgement source
+
+- Include a spoken and written acknowledgement for inspiration from `github/awesome-copilot`.

--- a/wceu-2026/references/slide-to-source-mapping.md
+++ b/wceu-2026/references/slide-to-source-mapping.md
@@ -1,0 +1,37 @@
+---
+title: "Slide to Source Mapping"
+description: "Fast mapping from each slide to supporting repository files."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide to Source Mapping
+
+| Deck order | Slide brief | Theme | Primary files |
+| --- | --- | --- | --- |
+| 1 | [slide-01-hook-and-stakes.md](../slides/slide-01-hook-and-stakes.md) | Hook and stakes | `README.md`, `docs/AUTOMATION_GOVERNANCE.md` |
+| 2 | [slide-02-why-github-control-plane.md](../slides/slide-02-why-github-control-plane.md) | Control plane start | `README.md`, `.github/labels.yml`, `.github/issue-types.yml` |
+| 3 | [slide-03-inheritance-boundaries.md](../slides/slide-03-inheritance-boundaries.md) | Inheritance boundaries | `docs/SHARED_GITHUB_ADOPTION_GUIDE.md`, `instructions/labeling.instructions.md` |
+| 4 | [slide-04-control-plane-architecture.md](../slides/slide-04-control-plane-architecture.md) | Architecture | `README.md`, `AGENTS.md`, `instructions/file-organisation.instructions.md` |
+| 5 | [slide-05-canonical-governance-assets.md](../slides/slide-05-canonical-governance-assets.md) | Canonical governance assets | `.github/labels.yml`, `docs/LABEL_STRATEGY.md`, `instructions/coding-standards.instructions.md` |
+| 6 | [slide-17-issue-template-system.md](../slides/slide-17-issue-template-system.md) | Issue templates | `.github/ISSUE_TEMPLATE/config.yml`, `.github/ISSUE_TEMPLATE/README.md`, `.github/ISSUE_TEMPLATE/23-ai-ops.md` |
+| 7 | [slide-18-pr-template-system.md](../slides/slide-18-pr-template-system.md) | PR templates | `.github/PULL_REQUEST_TEMPLATE/README.md`, `.github/PULL_REQUEST_TEMPLATE/pr_feature.md`, `.github/PULL_REQUEST_TEMPLATE/pr_release.md` |
+| 8 | [slide-16-workflow-layer.md](../slides/slide-16-workflow-layer.md) | Workflow layer | `.github/workflows/labeling.yml`, `.github/workflows/release.yml`, `docs/WORKFLOWS.md` |
+| 9 | [slide-13-agent-layer.md](../slides/slide-13-agent-layer.md) | Agent layer | `agents/agent.md`, `agents/labeling.agent.md`, `ai/agents.md` |
+| 10 | [slide-14-skill-layer.md](../slides/slide-14-skill-layer.md) | Skill layer | `skills/SKILL_REGISTRY.json`, `skills/README.md`, `plugins/lightspeed-github-ops/skills/` |
+| 11 | [slide-15-hook-layer.md](../slides/slide-15-hook-layer.md) | Hook layer | `hooks/README.md`, `hooks/hook-registry.json`, `hooks/secrets-scanner/` |
+| 12 | [slide-19-ai-governance-model.md](../slides/slide-19-ai-governance-model.md) | AI governance model | `AGENTS.md`, `ai/RUNNERS.md`, `instructions/automation.instructions.md`, `docs/AUTOMATION_GOVERNANCE.md` |
+| 13 | [slide-06-why-we-pivoted.md](../slides/slide-06-why-we-pivoted.md) | Pivot rationale | `docs/MIGRATION.md`, `docs/PLUGIN_PACK_ROADMAP.md`, `plugins/README.md` |
+| 14 | [slide-07-plugin-pack-architecture.md](../slides/slide-07-plugin-pack-architecture.md) | Plugin pack internals | `plugins/lightspeed-github-ops/README.md` |
+| 15 | [slide-08-multi-platform-parity.md](../slides/slide-08-multi-platform-parity.md) | Multi-platform parity | `plugins/lightspeed-github-ops/*.json`, `skills/SKILL_REGISTRY.json` |
+| 16 | [slide-09-quality-and-release-gates.md](../slides/slide-09-quality-and-release-gates.md) | Quality and release | `docs/RELEASE_PROCESS.md`, `docs/TESTING.md`, `.github/workflows/` |
+| 17 | [slide-10-metrics-and-governance-outcomes.md](../slides/slide-10-metrics-and-governance-outcomes.md) | Metrics and governance | `docs/METRICS.md`, `docs/GOVERNANCE_REVISION_LOG.md` |
+| 18 | [slide-11-lessons-and-anti-patterns.md](../slides/slide-11-lessons-and-anti-patterns.md) | Lessons learned | `docs/override-policy.md`, `instructions/spec-driven-workflow.instructions.md` |
+| 19 | [slide-12-adoption-playbook.md](../slides/slide-12-adoption-playbook.md) | Adoption path | `docs/SHARED_GITHUB_ADOPTION_GUIDE.md`, `plugins/PLUGIN_MANIFEST.json` |
+| 20 | [slide-20-ecosystem-and-acknowledgements.md](../slides/slide-20-ecosystem-and-acknowledgements.md) | Ecosystem and acknowledgements | `plugins/README.md`, `plugins/PLUGIN_MANIFEST.json`, `docs/ROADMAP.md` |
+
+## Attribution reminder
+
+Include this line on the References page and in spoken closing:
+
+"With thanks to `github/awesome-copilot` for inspiration across skills, agents, and workflow patterns."

--- a/wceu-2026/slides/slide-01-hook-and-stakes.md
+++ b/wceu-2026/slides/slide-01-hook-and-stakes.md
@@ -1,0 +1,44 @@
+---
+title: "Slide 01 - Hook and Stakes"
+description: "Open with the operational pain and why this matters now."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 01 - Hook and Stakes
+
+## Slide goal
+
+Establish urgency: teams are shipping across many repositories, but governance and automation are fragmented.
+
+## Key points
+
+- WordPress agencies and product teams scale repos faster than standards.
+- Inconsistent labels, templates, and release process create delivery risk.
+- The objective is not more process; it is reliable flow.
+
+## Speaker expansion notes
+
+- Frame this as a systems problem, not a tooling trend.
+- Position AI tooling as an acceleration force that magnifies drift if governance is weak.
+
+## Evidence anchors
+
+- `README.md`
+- `docs/AUTOMATION_GOVERNANCE.md`
+- `docs/ORGANIZATION.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-02-why-github-control-plane.md
+++ b/wceu-2026/slides/slide-02-why-github-control-plane.md
@@ -1,0 +1,46 @@
+---
+title: "Slide 02 - Why a .github Control Plane"
+description: "Explain why centralising standards in one .github repo was the first successful step."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 02 - Why a .github Control Plane
+
+## Slide goal
+
+Show how one `.github` repository reduced chaos by centralising reusable governance and automation defaults.
+
+## Key points
+
+- Shared community health and governance conventions.
+- Canonical labels, issue types, and template strategy.
+- Reusable workflows and instruction standards.
+
+## Speaker expansion notes
+
+- Emphasise this was a practical response to repeated delivery friction.
+- Mention the control-plane mental model: one source of truth, many consuming repos.
+
+## Evidence anchors
+
+- `README.md`
+- `.github/labels.yml`
+- `.github/issue-types.yml`
+- `.github/labeler.yml`
+- `.github/workflows/`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-03-inheritance-boundaries.md
+++ b/wceu-2026/slides/slide-03-inheritance-boundaries.md
@@ -1,0 +1,45 @@
+---
+title: "Slide 03 - Inheritance Boundaries"
+description: "Clarify what central .github can and cannot enforce by default."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 03 - Inheritance Boundaries
+
+## Slide goal
+
+Prevent over-claiming by clearly showing inheritance limits and where additional mechanisms are required.
+
+## Key points
+
+- Some assets inherit naturally; many do not.
+- Drift still appears without explicit sync and validation.
+- Governance needs both policy and execution tooling.
+
+## Speaker expansion notes
+
+- Keep this honest and practical.
+- Use this slide to build trust with technical audiences.
+
+## Evidence anchors
+
+- `docs/SHARED_GITHUB_ADOPTION_GUIDE.md`
+- `docs/AUTOMATION_GOVERNANCE.md`
+- `instructions/labeling.instructions.md`
+- `instructions/file-organisation.instructions.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-04-control-plane-architecture.md
+++ b/wceu-2026/slides/slide-04-control-plane-architecture.md
@@ -1,0 +1,45 @@
+---
+title: "Slide 04 - Control Plane Architecture"
+description: "Visualise the architecture of governance data, workflows, and standards."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 04 - Control Plane Architecture
+
+## Slide goal
+
+Give the audience a clear model of how standards, instructions, and automation are organised.
+
+## Key points
+
+- Governance files in `.github/`.
+- Portable assets in top-level folders (`agents/`, `skills/`, `workflows/`, `instructions/`).
+- Standards and docs in `docs/` and instruction packs.
+
+## Speaker expansion notes
+
+- Explain the boundary between repo-local control plane and portable AI assets.
+- Mention why this separation helps long-term maintainability.
+
+## Evidence anchors
+
+- `README.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `instructions/file-organisation.instructions.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-05-canonical-governance-assets.md
+++ b/wceu-2026/slides/slide-05-canonical-governance-assets.md
@@ -1,0 +1,46 @@
+---
+title: "Slide 05 - Canonical Governance Assets"
+description: "Show the concrete governance assets that made scaling possible."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 05 - Canonical Governance Assets
+
+## Slide goal
+
+Demonstrate that standardisation was achieved through concrete, versioned assets.
+
+## Key points
+
+- Label taxonomy and one-hot enforcement strategy.
+- Issue types and template consistency.
+- Coding, quality, and documentation instructions.
+
+## Speaker expansion notes
+
+- Highlight that canonical data is what makes automation safe.
+- Show how this improves onboarding and reporting.
+
+## Evidence anchors
+
+- `.github/labels.yml`
+- `.github/issue-types.yml`
+- `instructions/coding-standards.instructions.md`
+- `instructions/linting.instructions.md`
+- `docs/LABEL_STRATEGY.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-06-why-we-pivoted.md
+++ b/wceu-2026/slides/slide-06-why-we-pivoted.md
@@ -1,0 +1,44 @@
+---
+title: "Slide 06 - Why We Pivoted"
+description: "Explain why centralisation alone was insufficient and why a plugin model emerged."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 06 - Why We Pivoted
+
+## Slide goal
+
+Make the strategic pivot explicit: from a central repo pattern to a distributable product model.
+
+## Key points
+
+- Tool ecosystems expanded quickly.
+- Teams needed reusable capability, not just central documentation.
+- Installable packs reduce adoption friction and drift.
+
+## Speaker expansion notes
+
+- Phrase this as evolution, not replacement.
+- Keep continuity: same governance goals, better deployment model.
+
+## Evidence anchors
+
+- `docs/MIGRATION.md`
+- `docs/PLUGIN_PACK_ROADMAP.md`
+- `plugins/README.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-07-plugin-pack-architecture.md
+++ b/wceu-2026/slides/slide-07-plugin-pack-architecture.md
@@ -1,0 +1,44 @@
+---
+title: "Slide 07 - Plugin Pack Architecture"
+description: "Break down what sits inside a plugin pack and why it matters."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 07 - Plugin Pack Architecture
+
+## Slide goal
+
+Show the practical structure of an installable pack.
+
+## Key points
+
+- Pack includes skills, agents, hooks, and platform manifests.
+- A pack is a reusable capability module.
+- `lightspeed-github-ops` is the reference implementation.
+
+## Speaker expansion notes
+
+- Connect components to outcomes: consistency, speed, and safer automation.
+
+## Evidence anchors
+
+- `plugins/lightspeed-github-ops/README.md`
+- `plugins/lightspeed-github-ops/skills/`
+- `plugins/lightspeed-github-ops/agents/`
+- `plugins/lightspeed-github-ops/hooks/`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-08-multi-platform-parity.md
+++ b/wceu-2026/slides/slide-08-multi-platform-parity.md
@@ -1,0 +1,46 @@
+---
+title: "Slide 08 - Multi-Platform Parity"
+description: "Explain manifest parity across Copilot, Claude Code, Codex, and Gemini."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 08 - Multi-Platform Parity
+
+## Slide goal
+
+Show how one governance intent can be deployed across multiple AI coding toolchains.
+
+## Key points
+
+- Tool-specific manifests with shared capability intent.
+- Platform parity reduces behavioural surprises.
+- Registry and scoped validation support staged rollout.
+
+## Speaker expansion notes
+
+- Mention parity as a DevEx and risk-control practice.
+- Clarify that parity is never perfect but can be managed explicitly.
+
+## Evidence anchors
+
+- `plugins/lightspeed-github-ops/.codex-plugin/plugin.json`
+- `plugins/lightspeed-github-ops/.claude-plugin/plugin.json`
+- `plugins/lightspeed-github-ops/.gemini-plugin/plugin.json`
+- `plugins/lightspeed-github-ops/copilot-plugin.json`
+- `skills/SKILL_REGISTRY.json`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-09-quality-and-release-gates.md
+++ b/wceu-2026/slides/slide-09-quality-and-release-gates.md
@@ -1,0 +1,46 @@
+---
+title: "Slide 09 - Quality and Release Gates"
+description: "Show how validation, linting, and release workflows are enforced."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 09 - Quality and Release Gates
+
+## Slide goal
+
+Demonstrate that speed was balanced by enforceable quality and release discipline.
+
+## Key points
+
+- Linting and validation are codified.
+- Release process is documented and automatable.
+- Governance and quality checks are part of daily flow.
+
+## Speaker expansion notes
+
+- Tie this directly to reduced release anxiety.
+- Keep language practical: fewer surprises, earlier detection.
+
+## Evidence anchors
+
+- `docs/RELEASE_PROCESS.md`
+- `docs/TESTING.md`
+- `docs/LINTING.md`
+- `.github/workflows/`
+- `docs/PLUGIN_INSTALLATION_GUIDE.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-10-metrics-and-governance-outcomes.md
+++ b/wceu-2026/slides/slide-10-metrics-and-governance-outcomes.md
@@ -1,0 +1,45 @@
+---
+title: "Slide 10 - Metrics and Governance Outcomes"
+description: "Connect governance system design to measurable outcomes and accountability."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 10 - Metrics and Governance Outcomes
+
+## Slide goal
+
+Show how the system supports accountability, not just automation.
+
+## Key points
+
+- Metrics and reporting are explicit workstreams.
+- Governance includes roles, process, and standards.
+- Documentation is treated as an operational asset.
+
+## Speaker expansion notes
+
+- Avoid claiming precise numeric outcomes unless data is available in repo.
+- Focus on what is instrumented and reviewable.
+
+## Evidence anchors
+
+- `docs/METRICS.md`
+- `docs/GOVERNANCE_REVISION_LOG.md`
+- `docs/AUTOMATION_GOVERNANCE.md`
+- `plugins/lightspeed-metrics-and-reporting/`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-11-lessons-and-anti-patterns.md
+++ b/wceu-2026/slides/slide-11-lessons-and-anti-patterns.md
@@ -1,0 +1,46 @@
+---
+title: "Slide 11 - Lessons and Anti-Patterns"
+description: "Capture hard lessons and what to avoid when centralising governance and AI ops."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 11 - Lessons and Anti-Patterns
+
+## Slide goal
+
+Give honest implementation guidance by naming trade-offs and failure patterns.
+
+## Key points
+
+- Over-centralisation can block local progress.
+- Too many templates reduce adoption.
+- Standards without validation drift over time.
+- Automation requires explicit human checkpoints.
+
+## Speaker expansion notes
+
+- Use this slide to show maturity and credibility.
+- Pair each anti-pattern with a mitigation.
+
+## Evidence anchors
+
+- `docs/override-policy.md`
+- `instructions/labeling.instructions.md`
+- `instructions/spec-driven-workflow.instructions.md`
+- `docs/PLUGIN_PACK_ROADMAP.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-12-adoption-playbook.md
+++ b/wceu-2026/slides/slide-12-adoption-playbook.md
@@ -1,0 +1,47 @@
+---
+title: "Slide 12 - Adoption Playbook"
+description: "Close with a practical implementation sequence other teams can follow."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 12 - Adoption Playbook
+
+## Slide goal
+
+Leave the audience with a concrete path to apply the model in their own organisations.
+
+## Key points
+
+- Start with one governance outcome, not a full platform rewrite.
+- Roll out one plugin pack and validate behaviour.
+- Scale pack usage once parity and quality checks are stable.
+
+## 30/60/90 framing
+
+- 30 days: baseline governance, labels, and templates.
+- 60 days: reusable workflows and first plugin pack install.
+- 90 days: multi-tool parity, reporting cadence, and contribution model.
+
+## Evidence anchors
+
+- `docs/SHARED_GITHUB_ADOPTION_GUIDE.md`
+- `docs/PLUGIN_INSTALLATION_GUIDE.md`
+- `plugins/PLUGIN_MANIFEST.json`
+- `plugins/README.md`
+- `docs/ROADMAP.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-13-agent-layer.md
+++ b/wceu-2026/slides/slide-13-agent-layer.md
@@ -1,0 +1,46 @@
+---
+title: "Slide 13 - Agent Layer"
+description: "Explain how agent specifications structure operational automation."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 13 - Agent Layer
+
+## Slide goal
+
+Show how agents make governance tasks executable and repeatable across repositories.
+
+## Key points
+
+- Agents capture role, scope, guardrails, and expected outputs.
+- Multiple specialist agents cover issues, labels, review, release, and metrics.
+- Agent specifications support clarity for both humans and AI assistants.
+
+## Speaker expansion notes
+
+- Explain the difference between a generic assistant and a scoped operations agent.
+- Mention that this improves consistency without removing human approvals.
+
+## Evidence anchors
+
+- `agents/agent.md`
+- `agents/labeling.agent.md`
+- `agents/release.agent.md`
+- `agents/reviewer.agent.md`
+- `ai/agents.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-14-skill-layer.md
+++ b/wceu-2026/slides/slide-14-skill-layer.md
@@ -1,0 +1,45 @@
+---
+title: "Slide 14 - Skill Layer"
+description: "Explain reusable skills as practical capability units."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 14 - Skill Layer
+
+## Slide goal
+
+Show how skills package repeatable, high-quality workflows that can be installed and reused.
+
+## Key points
+
+- Skills are scoped recipes with clear entry points.
+- Registry-driven skills support phased rollout and parity checks.
+- Skills bridge policy documents and execution behaviour.
+
+## Speaker expansion notes
+
+- Use one example skill from `lightspeed-github-ops`.
+- Explain why skills reduce prompt drift and tribal knowledge.
+
+## Evidence anchors
+
+- `skills/README.md`
+- `skills/SKILL_REGISTRY.json`
+- `plugins/lightspeed-github-ops/skills/lightspeed-pr-review/SKILL.md`
+- `plugins/lightspeed-github-ops/skills/lightspeed-label-governance/SKILL.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-15-hook-layer.md
+++ b/wceu-2026/slides/slide-15-hook-layer.md
@@ -1,0 +1,46 @@
+---
+title: "Slide 15 - Hook Layer"
+description: "Show hook-based guardrails and execution safety checks."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 15 - Hook Layer
+
+## Slide goal
+
+Describe how hooks provide guardrails, session controls, and policy enforcement at execution time.
+
+## Key points
+
+- Hooks enforce safety boundaries and reduce accidental policy drift.
+- Hook registry improves discoverability and governance.
+- Hooks complement agents and skills by handling cross-cutting controls.
+
+## Speaker expansion notes
+
+- Position hooks as protective infrastructure, not extra bureaucracy.
+- Mention secrets and tool-usage guardrails.
+
+## Evidence anchors
+
+- `hooks/README.md`
+- `hooks/hook-registry.json`
+- `hooks/secrets-scanner/`
+- `hooks/tool-guardian/`
+- `hooks/session-logger/`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-16-workflow-layer.md
+++ b/wceu-2026/slides/slide-16-workflow-layer.md
@@ -1,0 +1,46 @@
+---
+title: "Slide 16 - Workflow Layer"
+description: "Explain orchestration through GitHub workflows for daily operations."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 16 - Workflow Layer
+
+## Slide goal
+
+Show how GitHub workflows operationalise governance and quality continuously.
+
+## Key points
+
+- Dedicated workflows for labeling, linting, testing, release, reporting, and metrics.
+- Workflows provide consistent execution triggers and auditability.
+- This layer connects repository events to governance actions.
+
+## Speaker expansion notes
+
+- Use a concrete event path (PR opened -> labeling + linting + review automation).
+- Reinforce that workflows are transparent and inspectable.
+
+## Evidence anchors
+
+- `.github/workflows/labeling.yml`
+- `.github/workflows/linting.yml`
+- `.github/workflows/release.yml`
+- `.github/workflows/reviewer.yml`
+- `docs/WORKFLOWS.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-17-issue-template-system.md
+++ b/wceu-2026/slides/slide-17-issue-template-system.md
@@ -1,0 +1,46 @@
+---
+title: "Slide 17 - Issue Template System"
+description: "Explain issue template strategy and structured intake."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 17 - Issue Template System
+
+## Slide goal
+
+Show how issue templates improve intake quality, routing, and triage outcomes.
+
+## Key points
+
+- Template catalogue supports different work types.
+- Configured templates improve required metadata quality.
+- Structured intake reduces back-and-forth and speeds assignment.
+
+## Speaker expansion notes
+
+- Acknowledge trade-off: too many templates can overwhelm contributors.
+- Explain active curation and simplification strategy.
+
+## Evidence anchors
+
+- `.github/ISSUE_TEMPLATE/config.yml`
+- `.github/ISSUE_TEMPLATE/README.md`
+- `.github/ISSUE_TEMPLATE/23-ai-ops.md`
+- `.github/ISSUE_TEMPLATE/03-feature.md`
+- `.github/ISSUE_TEMPLATE/02-bug.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-18-pr-template-system.md
+++ b/wceu-2026/slides/slide-18-pr-template-system.md
@@ -1,0 +1,46 @@
+---
+title: "Slide 18 - PR Template System"
+description: "Show PR templates as quality and release-readiness checks."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 18 - PR Template System
+
+## Slide goal
+
+Show how PR templates align change intent, review quality, and release confidence.
+
+## Key points
+
+- Template variants match PR intent (feature, bug, release, refactor, docs).
+- Prompts enforce clearer change summaries and validation notes.
+- PR templates create better review handoffs across teams.
+
+## Speaker expansion notes
+
+- Connect template quality to faster approvals and fewer review loops.
+- Mention compatibility with automated checks and reviewer workflows.
+
+## Evidence anchors
+
+- `.github/PULL_REQUEST_TEMPLATE/README.md`
+- `.github/PULL_REQUEST_TEMPLATE/pr_feature.md`
+- `.github/PULL_REQUEST_TEMPLATE/pr_bug.md`
+- `.github/PULL_REQUEST_TEMPLATE/pr_release.md`
+- `docs/PR_CREATION_PROCESS.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-19-ai-governance-model.md
+++ b/wceu-2026/slides/slide-19-ai-governance-model.md
@@ -1,0 +1,47 @@
+---
+title: "Slide 19 - AI Governance Model"
+description: "Explain policy, instruction hierarchy, and guardrails for AI-assisted delivery."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 19 - AI Governance Model
+
+## Slide goal
+
+Explain how AI usage is governed through explicit standards, instructions, and review boundaries.
+
+## Key points
+
+- AI operations are documented and version-controlled.
+- Instruction hierarchy defines behaviour and boundaries.
+- Governance includes accessibility, security, quality, and transparency.
+
+## Speaker expansion notes
+
+- Emphasise this is operations governance, not generic AI hype.
+- Mention that human accountability remains explicit.
+
+## Evidence anchors
+
+- `AGENTS.md`
+- `ai/RUNNERS.md`
+- `ai/Claude.md`
+- `instructions/automation.instructions.md`
+- `instructions/a11y.instructions.md`
+- `docs/AUTOMATION_GOVERNANCE.md`
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/slides/slide-20-ecosystem-and-acknowledgements.md
+++ b/wceu-2026/slides/slide-20-ecosystem-and-acknowledgements.md
@@ -1,0 +1,49 @@
+---
+title: "Slide 20 - Ecosystem and Acknowledgements"
+description: "Close with adoption next steps and acknowledgement of open-source inspiration."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Slide 20 - Ecosystem and Acknowledgements
+
+## Slide goal
+
+Close with practical next actions and acknowledge ecosystem influence.
+
+## Key points
+
+- This model is portable and can be adopted incrementally.
+- Start from one governance pain-point and one plugin pack.
+- Open-source patterns accelerated delivery learning.
+
+## Speaker expansion notes
+
+- Include explicit thanks to `github/awesome-copilot`.
+- Invite the audience to adapt, not copy blindly.
+
+## Evidence anchors
+
+- `plugins/README.md`
+- `plugins/PLUGIN_MANIFEST.json`
+- `docs/ROADMAP.md`
+- `wceu-2026/references/repo-source-index.md`
+
+## Acknowledgement line
+
+With thanks to `github/awesome-copilot` for the inspiration and practical patterns that helped shape this direction.
+
+## Slide content brief
+
+- Use one clear headline that states the slide message.
+- Keep body content to 3 bullets maximum based on the `Key points` section.
+- Include one proof item from `Evidence anchors` (quote, file path, or short data point).
+- Add one speaker cue line in small text if needed; avoid paragraph-heavy copy.
+
+## Slide style brief (NotebookLM-safe)
+
+- Keep layout simple: title + 3 bullets + one visual zone.
+- Use minimal visuals (one icon, one screenshot, or one simple diagram only).
+- Avoid dense process diagrams, nested callouts, and complex animation.
+- Keep on-slide text short (roughly 25-40 words total where possible).
+- Use high contrast and consistent spacing; prioritise readability over decoration.

--- a/wceu-2026/talk-outline-25min.md
+++ b/wceu-2026/talk-outline-25min.md
@@ -1,0 +1,78 @@
+---
+title: "Talk Outline (25 Minutes)"
+description: "Speaker outline for WCEU 2026: from central .github governance repo to installable AI-ops plugin packs."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Talk Outline (25 Minutes)
+
+## Talk title
+
+One `.github` Repo for All Your WordPress Projects: From Central Governance to Installable AI-Ops Plugins
+
+## Core narrative
+
+- Phase 1: Centralise standards and operations in one `.github` control plane.
+- Phase 2: Discover centralisation limits (inheritance, drift, tool fragmentation).
+- Phase 3: Productise governance into installable plugin packs for AI coding tools.
+- Phase 4: Preserve human judgement with transparent automation and validation.
+
+## Timeline
+
+1. `00:00-03:00` - Problem framing, control plane rationale, and boundaries.
+2. `03:00-08:00` - Canonical governance assets and template systems.
+3. `08:00-14:00` - Automation stack deep dive: workflows, agents, skills, hooks, AI governance.
+4. `14:00-18:00` - Pivot to installable plugin packs and platform parity.
+5. `18:00-22:00` - Quality, release, metrics, and practical trade-offs.
+6. `22:00-25:00` - Adoption path, ecosystem credit, and close.
+
+## Presentation order (20 slides)
+
+1. [Slide 01 - Hook and stakes](slides/slide-01-hook-and-stakes.md)
+2. [Slide 02 - Why `.github` control plane](slides/slide-02-why-github-control-plane.md)
+3. [Slide 03 - Inheritance boundaries](slides/slide-03-inheritance-boundaries.md)
+4. [Slide 04 - Control-plane architecture](slides/slide-04-control-plane-architecture.md)
+5. [Slide 05 - Canonical governance assets](slides/slide-05-canonical-governance-assets.md)
+6. [Slide 17 - Issue template system](slides/slide-17-issue-template-system.md)
+7. [Slide 18 - PR template system](slides/slide-18-pr-template-system.md)
+8. [Slide 16 - Workflow layer](slides/slide-16-workflow-layer.md)
+9. [Slide 13 - Agent layer](slides/slide-13-agent-layer.md)
+10. [Slide 14 - Skill layer](slides/slide-14-skill-layer.md)
+11. [Slide 15 - Hook layer](slides/slide-15-hook-layer.md)
+12. [Slide 19 - AI governance model](slides/slide-19-ai-governance-model.md)
+13. [Slide 06 - Why we pivoted](slides/slide-06-why-we-pivoted.md)
+14. [Slide 07 - Plugin pack architecture](slides/slide-07-plugin-pack-architecture.md)
+15. [Slide 08 - Multi-platform parity](slides/slide-08-multi-platform-parity.md)
+16. [Slide 09 - Quality and release gates](slides/slide-09-quality-and-release-gates.md)
+17. [Slide 10 - Metrics and governance outcomes](slides/slide-10-metrics-and-governance-outcomes.md)
+18. [Slide 11 - Lessons and anti-patterns](slides/slide-11-lessons-and-anti-patterns.md)
+19. [Slide 12 - Adoption playbook](slides/slide-12-adoption-playbook.md)
+20. [Slide 20 - Ecosystem and acknowledgements](slides/slide-20-ecosystem-and-acknowledgements.md)
+
+## Legacy numeric map (file numbering)
+
+1. Hook and stakes
+2. Why `.github` was the first move
+3. What inheritance does and does not give you
+4. Control plane architecture
+5. Governance assets and canonical data
+6. Why we pivoted to installable plugin packs
+7. Plugin pack architecture (inside one pack)
+8. Multi-platform manifest parity
+9. Release and quality gates
+10. Metrics and governance outcomes
+11. Lessons learned and anti-patterns
+12. Practical 30/60/90 rollout plan
+13. Agent layer and operational role design
+14. Skill layer and reusable capability design
+15. Hook layer and guardrail enforcement
+16. Workflow layer and GitHub Actions orchestration
+17. Issue template system and structured intake
+18. PR template system and review quality
+19. AI governance model and instruction hierarchy
+20. Ecosystem acknowledgements and next actions
+
+## Key message to repeat
+
+Same governance principles, better delivery model: central source of truth plus portable installable execution.

--- a/wceu-2026/website/mini-site-plan.md
+++ b/wceu-2026/website/mini-site-plan.md
@@ -1,0 +1,47 @@
+---
+title: "Mini Website Plan"
+description: "Information architecture and content requirements for a mini website explaining the WCEU 2026 talk."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Mini Website Plan
+
+## Purpose
+
+Create a compact website that explains the talk in layered depth:
+
+- fast overview for conference attendees
+- evidence-backed detail for practitioners
+- actionable adoption plan for teams
+
+## Proposed pages
+
+1. `Home` - title, abstract, speaker bio, key outcomes.
+2. `The Problem` - repo sprawl, drift, and governance pain.
+3. `Control Plane v1` - what the central `.github` solved.
+4. `Why We Pivoted` - limitations and lessons.
+5. `Plugin Packs` - installable model and multi-tool manifests.
+6. `Results` - quality, release, and governance impacts.
+7. `Adoption Guide` - 30/60/90 rollout for other teams.
+8. `References` - repo-only source index.
+
+## Content principles
+
+- Every important claim links back to repository files.
+- Separate implemented capabilities from roadmap items.
+- Speak to both agency operators and senior engineers.
+- Keep automation transparent; keep human review explicit.
+
+## Required site assets
+
+- speaker headshot and bio snippet
+- architecture diagram (control plane vs plugin packs)
+- slide summaries (from `wceu-2026/slides/`)
+- FAQ and myths section from NotebookLM output
+
+## Attribution
+
+Add an acknowledgement section:
+
+"This work was informed and inspired by `github/awesome-copilot` and the wider open-source Copilot ecosystem."

--- a/wceu-2026/website/page-copy-starter.md
+++ b/wceu-2026/website/page-copy-starter.md
@@ -1,0 +1,32 @@
+---
+title: "Page Copy Starter"
+description: "Draft copy scaffolding for mini website pages based on the talk narrative."
+last_updated: "2026-05-28"
+owners: ["Ash Shaw"]
+---
+
+# Page Copy Starter
+
+## Home
+
+A practical case study of how `lightspeedwp/.github` evolved from a central governance repository into installable plugin packs for AI coding tools, while preserving quality, accessibility, and release discipline.
+
+## The Problem
+
+WordPress teams scaled repositories faster than standards. Triage drift, inconsistent workflows, and release uncertainty created operational drag.
+
+## Control Plane
+
+The first breakthrough was centralising governance assets, labels, templates, instructions, and workflows into one control-plane repository.
+
+## The Pivot
+
+As AI tooling expanded, a central repo alone was not enough. We moved to installable plugin packs so capabilities could be distributed with parity across tools.
+
+## Outcomes
+
+The result was a clearer model: central source of truth, portable execution packs, explicit validation, and retained human judgement.
+
+## Acknowledgements
+
+This work was significantly inspired by `github/awesome-copilot`, whose open practices and examples helped shape our approach.


### PR DESCRIPTION
## Summary
- add the WCEU 2026 talk asset pack content
- add slide briefs, references, NotebookLM prompts, and website starter copy
- preserve the work on a draft PR for review against current develop

## Validation
- Branch pushed successfully
- No additional validation run in this pass beyond branch/worktree inspection