### PR TITLE
Plan Awesome GitHub site phases

### DIFF
--- a/.github/projects/active/awesome-github-site/ISSUE_EXECUTION_PLAN.md
+++ b/.github/projects/active/awesome-github-site/ISSUE_EXECUTION_PLAN.md
@@ -6,6 +6,8 @@ version: "1.0.0"
 created_date: "2026-06-03"
 last_updated: "2026-06-03"
 status: active
+stability: stable
+domain: website
 owners:
   - Ash Shaw
 tags:

--- a/.github/projects/active/awesome-github-site/ISSUE_EXECUTION_PLAN.md
+++ b/.github/projects/active/awesome-github-site/ISSUE_EXECUTION_PLAN.md
@@ -1,0 +1,75 @@
+---
+file_type: documentation
+title: "Issue Execution Plan - Awesome GitHub Site"
+description: "Ordered issue plan for the Awesome GitHub website, covering the phase 1 MVP and the phase 2 expansion."
+version: "1.0.0"
+created_date: "2026-06-03"
+last_updated: "2026-06-03"
+status: active
+owners:
+  - Ash Shaw
+tags:
+  - planning
+  - issues
+  - website
+  - opsx
+---
+
+# Issue Execution Plan
+
+## 3-Bullet Summary
+
+- Value: gives the website a strict delivery sequence so the first release stays small and useful.
+- Risks: phase 2 material leaking into phase 1, unclear page ownership, and copy drift away from the source briefs.
+- Next step: lock the phase 1 issue chain, then hold phase 2 as the expansion path after the MVP is stable.
+
+## Delivery Order
+
+### Phase 1
+
+1. Source audit and scope lock
+2. Phase 1 information architecture and page map
+3. Phase 1 copy normalisation from the briefing docs
+4. MVP site scaffold and page build
+5. Validation and launch readiness
+
+### Phase 2
+
+1. Full information architecture and content model
+2. Layout and browsing system expansion
+3. Content migration and page population
+4. Search or discovery enhancements
+5. Visual polish, accessibility pass, and full launch validation
+
+## Suggested Issue Structure
+
+### Phase 1
+
+- Parent: `Awesome GitHub Site - Phase 1 MVP`
+- Child 1: `Source audit and scope lock`
+- Child 2: `Information architecture and page map`
+- Child 3: `Copy normalisation and content model`
+- Child 4: `MVP site scaffold and page build`
+- Child 5: `Validation and launch readiness`
+
+### Phase 2
+
+- Parent: `Awesome GitHub Site - Phase 2 Full Website`
+- Child 1: `Full information architecture and content model`
+- Child 2: `Category browsing and layout system`
+- Child 3: `Content population and resource structure`
+- Child 4: `Discovery, search, and supporting guides`
+- Child 5: `Accessibility, polish, and launch validation`
+
+## OpenSpec Notes
+
+- Use the phase split above when preparing `/opsx:propose` inputs.
+- Keep proposal files phase-specific so phase 1 can ship without waiting for phase 2 detail.
+- Treat the normalised briefs in `briefs/` as the source of truth for the first planning pass.
+
+## Acceptance Criteria
+
+- Phase 1 is bounded to 1-3 pages and can be launched independently.
+- Phase 2 expands the MVP without replacing the phase 1 structure.
+- The source briefs are aligned to repo documentation standards.
+- The active-project tracker reflects the new workstream.

--- a/.github/projects/active/awesome-github-site/README.md
+++ b/.github/projects/active/awesome-github-site/README.md
@@ -6,6 +6,8 @@ version: "1.0.0"
 created_date: "2026-06-03"
 last_updated: "2026-06-03"
 status: active
+stability: stable
+domain: website
 owners:
   - Ash Shaw
 tags:

--- a/.github/projects/active/awesome-github-site/README.md
+++ b/.github/projects/active/awesome-github-site/README.md
@@ -1,0 +1,78 @@
+---
+file_type: documentation
+title: "Awesome GitHub Site"
+description: "Active project plan for the Awesome GitHub website, split into a launchable phase 1 MVP and a fuller phase 2 site."
+version: "1.0.0"
+created_date: "2026-06-03"
+last_updated: "2026-06-03"
+status: active
+owners:
+  - Ash Shaw
+tags:
+  - planning
+  - website
+  - github
+  - opsx
+  - open-spec
+---
+
+# Awesome GitHub Site
+
+## 3-Bullet Summary
+
+- Value: turns the reference material into a small, shippable GitHub site first, then expands it into the fuller catalogue-style experience.
+- Risks: phase creep, copy that stays too talk-specific, and a phase 2 structure that gets pulled into phase 1 too early.
+- Next step: run the phase 1 issue chain first, using the normalised briefs in `briefs/` as the source of truth.
+
+## Overview
+
+`Awesome GitHub` is the working name for a GitHub-led website inspired by the structure and content discipline of `awesome-copilot`.
+
+The delivery is intentionally split:
+
+1. Phase 1 ships a compact 1-3 page MVP.
+2. Phase 2 expands that MVP into the full resource-style site.
+
+## Project Inputs
+
+- Reference site: `awesome-copilot`
+- Source repository for reference structure: `github/awesome-copilot/website`
+- Source briefs:
+  - `briefs/mini-site-plan.md`
+  - `briefs/page-copy-starter.md`
+
+## Project Outputs
+
+- Phase 1 planning and issue sequence
+- Phase 2 expansion planning and issue sequence
+- Normalised source briefs aligned to repo conventions
+- Execution tracker updates in `next-issues-execution-plan.md`
+
+## Phase Split
+
+### Phase 1
+
+Build the smallest useful version of the site:
+
+- Home
+- Why this exists
+- References or Sources
+
+### Phase 2
+
+Expand the site into the full experience:
+
+- resource catalogue pages
+- category browsing
+- richer navigation
+- supporting guides and discovery flows
+
+## References
+
+- [Phase 1 plan](phase-1/README.md)
+- [Phase 2 plan](phase-2/README.md)
+- [Issue execution plan](ISSUE_EXECUTION_PLAN.md)
+- [Run log](RUN_LOG.md)
+- [OpenSpec guide](openspec/README.md)
+- [Mini site brief](briefs/mini-site-plan.md)
+- [Page copy brief](briefs/page-copy-starter.md)

--- a/.github/projects/active/awesome-github-site/RUN_LOG.md
+++ b/.github/projects/active/awesome-github-site/RUN_LOG.md
@@ -6,6 +6,8 @@ version: "1.0.0"
 created_date: "2026-06-03"
 last_updated: "2026-06-03"
 status: active
+stability: stable
+domain: opsx
 owners:
   - Ash Shaw
 tags:

--- a/.github/projects/active/awesome-github-site/RUN_LOG.md
+++ b/.github/projects/active/awesome-github-site/RUN_LOG.md
@@ -1,0 +1,43 @@
+---
+file_type: documentation
+title: "Run Log - Awesome GitHub Site"
+description: "Execution log for planning and proposal runs related to the Awesome GitHub website."
+version: "1.0.0"
+created_date: "2026-06-03"
+last_updated: "2026-06-03"
+status: active
+owners:
+  - Ash Shaw
+tags:
+  - planning
+  - opsx
+  - issues
+  - website
+---
+
+# Run Log
+
+## Instructions
+
+For each `/opsx:propose` run or planning pass, append a short entry using the pattern below.
+
+```markdown
+### YYYY-MM-DD HH:MM TZ - <entry-key>
+- command: `<command-or-n/a>`
+- expected-template: `<issue-template-or-n/a>`
+- result: `success | failed | partial`
+- github-issue-url: `<url-or-TBD>`
+- labels-applied: `[label1, label2, ...]`
+- notes: `<short summary of what changed or blocked progress>`
+```
+
+## Entries
+
+### 2026-06-03 00:00 Europe/Warsaw - setup
+
+- command: `n/a`
+- expected-template: `n/a`
+- result: `success`
+- github-issue-url: `n/a`
+- labels-applied: `[]`
+- notes: `Project plan initialised. Phase 1 and phase 2 paths are now separated and ready for issue drafting.`

--- a/.github/projects/active/awesome-github-site/briefs/mini-site-plan.md
+++ b/.github/projects/active/awesome-github-site/briefs/mini-site-plan.md
@@ -6,6 +6,8 @@ version: "1.0.0"
 created_date: "2026-06-03"
 last_updated: "2026-06-03"
 status: active
+stability: draft
+domain: website
 owners:
   - Ash Shaw
 tags:

--- a/.github/projects/active/awesome-github-site/briefs/mini-site-plan.md
+++ b/.github/projects/active/awesome-github-site/briefs/mini-site-plan.md
@@ -1,0 +1,62 @@
+---
+file_type: documentation
+title: "Mini Site Plan"
+description: "Phase 1 information architecture and content requirements for the initial Awesome GitHub website."
+version: "1.0.0"
+created_date: "2026-06-03"
+last_updated: "2026-06-03"
+status: active
+owners:
+  - Ash Shaw
+tags:
+  - planning
+  - content
+  - website
+  - phase-1
+---
+
+# Mini Site Plan
+
+## Purpose
+
+Create a compact website that explains the project in a small, launchable package.
+
+The first release should:
+
+- give visitors an immediate overview
+- explain why the site exists
+- provide a short, evidence-backed reference trail
+- stay small enough to ship before any catalogue expansion
+
+## Proposed Pages
+
+1. `Home` - title, purpose, and a short value proposition.
+2. `Why this exists` - the problem, the approach, and the reason the site exists.
+3. `References` - source links, acknowledgements, and supporting material.
+
+## Content Principles
+
+- Keep every claim short and sourceable.
+- Separate the launchable MVP from the broader phase 2 vision.
+- Keep the tone direct and practical.
+- Use the site to explain the project, not to repeat the full planning history.
+
+## Required Site Assets
+
+- a concise site title and subtitle
+- simple top navigation
+- a references section with source links
+- a lightweight footer with acknowledgements
+
+## Source Inputs
+
+- `../../../../../wceu-2026/website/mini-site-plan.md`
+- `../../../../../wceu-2026/website/page-copy-starter.md`
+- `../../../../../wceu-2026/website/`
+- `https://github.com/github/awesome-copilot/tree/main/website`
+
+## Alignment Notes
+
+- Treat the reference site as a structural guide, not a copy target.
+- Normalise talk-centric wording into site-centric wording.
+- Keep phase 1 small so it can ship independently.

--- a/.github/projects/active/awesome-github-site/briefs/page-copy-starter.md
+++ b/.github/projects/active/awesome-github-site/briefs/page-copy-starter.md
@@ -6,6 +6,8 @@ version: "1.0.0"
 created_date: "2026-06-03"
 last_updated: "2026-06-03"
 status: active
+stability: draft
+domain: website
 owners:
   - Ash Shaw
 tags:

--- a/.github/projects/active/awesome-github-site/briefs/page-copy-starter.md
+++ b/.github/projects/active/awesome-github-site/briefs/page-copy-starter.md
@@ -1,0 +1,41 @@
+---
+file_type: documentation
+title: "Page Copy Starter"
+description: "Draft copy scaffolding for the Awesome GitHub phase 1 pages."
+version: "1.0.0"
+created_date: "2026-06-03"
+last_updated: "2026-06-03"
+status: active
+owners:
+  - Ash Shaw
+tags:
+  - planning
+  - copy
+  - website
+  - phase-1
+---
+
+# Page Copy Starter
+
+## Home
+
+`Awesome GitHub` is a compact, GitHub-led website that explains how LightSpeed uses the `.github` repository as a practical control plane for planning, governance, and AI-assisted workflows.
+
+The first release focuses on a small, usable site that can ship quickly and then grow into a fuller catalogue-style experience.
+
+## Why this exists
+
+Repositories often become archives of files and workflows.
+
+This project treats `.github` as an operating layer instead:
+
+- templates and issue flows stay consistent
+- planning becomes easier to follow
+- governance stays visible
+- the site can evolve without losing its source-backed footing
+
+## References
+
+This site is informed by the open structure of `github/awesome-copilot` and by the LightSpeed planning material that shaped the first site brief.
+
+The references page should point to the key source documents, the repo history that supports the claims, and any acknowledgements that help explain the design direction.

--- a/.github/projects/active/awesome-github-site/openspec/README.md
+++ b/.github/projects/active/awesome-github-site/openspec/README.md
@@ -1,0 +1,56 @@
+---
+file_type: documentation
+title: "OpenSpec Proposal Guide - Awesome GitHub Site"
+description: "Guide for turning the Awesome GitHub phase plans into `/opsx:propose` inputs."
+version: "1.0.0"
+created_date: "2026-06-03"
+last_updated: "2026-06-03"
+status: active
+owners:
+  - Ash Shaw
+tags:
+  - openspec
+  - opsx
+  - issues
+  - website
+---
+
+# OpenSpec Proposal Guide
+
+## Purpose
+
+This folder exists to support the issue proposal workflow for the Awesome GitHub site.
+
+Use it after the planning docs are approved and the phase split is locked.
+
+## Expected Order
+
+### Phase 1
+
+1. Source audit and scope lock
+2. Phase 1 information architecture and page map
+3. Phase 1 copy normalisation
+4. MVP site scaffold and page build
+5. Validation and launch readiness
+
+### Phase 2
+
+1. Full information architecture and content model
+2. Layout and browsing system expansion
+3. Content migration and page population
+4. Search or discovery enhancements
+5. Visual polish, accessibility pass, and full launch validation
+
+## Inputs
+
+- `../phase-1/README.md`
+- `../phase-2/README.md`
+- `../ISSUE_EXECUTION_PLAN.md`
+- `../briefs/mini-site-plan.md`
+- `../briefs/page-copy-starter.md`
+
+## Notes
+
+- Keep phase 1 and phase 2 proposal files separate.
+- Use the normalised briefs as the initial source for `/opsx:propose`.
+- Update `RUN_LOG.md` after each proposal run.

--- a/.github/projects/active/awesome-github-site/openspec/README.md
+++ b/.github/projects/active/awesome-github-site/openspec/README.md
@@ -6,6 +6,8 @@ version: "1.0.0"
 created_date: "2026-06-03"
 last_updated: "2026-06-03"
 status: active
+stability: stable
+domain: opsx
 owners:
   - Ash Shaw
 tags:
@@ -53,4 +55,4 @@ Use it after the planning docs are approved and the phase split is locked.
 
 - Keep phase 1 and phase 2 proposal files separate.
 - Use the normalised briefs as the initial source for `/opsx:propose`.
-- Update `RUN_LOG.md` after each proposal run.
+- Update `./RUN_LOG.md` after each proposal run.

--- a/.github/projects/active/awesome-github-site/phase-1/README.md
+++ b/.github/projects/active/awesome-github-site/phase-1/README.md
@@ -6,6 +6,8 @@ version: "1.0.0"
 created_date: "2026-06-03"
 last_updated: "2026-06-03"
 status: active
+stability: stable
+domain: website
 owners:
   - Ash Shaw
 tags:

--- a/.github/projects/active/awesome-github-site/phase-1/README.md
+++ b/.github/projects/active/awesome-github-site/phase-1/README.md
@@ -1,0 +1,46 @@
+---
+file_type: documentation
+title: "Awesome GitHub Site - Phase 1"
+description: "Phase 1 plan for the initial launchable version of the Awesome GitHub website."
+version: "1.0.0"
+created_date: "2026-06-03"
+last_updated: "2026-06-03"
+status: active
+owners:
+  - Ash Shaw
+tags:
+  - planning
+  - phase-1
+  - website
+  - mvp
+---
+
+# Phase 1
+
+## 3-Bullet Summary
+
+- Value: ships a small but real site quickly so the project has a usable first outcome.
+- Risks: overbuilding the information architecture, adding catalogue behaviour too early, and letting the page count expand beyond the MVP.
+- Next step: define the 1-3 page shape and lock the copy before implementation starts.
+
+## Scope
+
+Phase 1 is intentionally narrow:
+
+- Home
+- Why this exists
+- References or Sources
+
+## Deliverables
+
+- A compact site shell with top navigation and footer
+- Clean, source-backed page copy
+- Basic visual treatment that can be extended later
+- A small validation checklist covering build and content consistency
+
+## Acceptance Criteria
+
+- The site can be built and served without phase 2 features.
+- The core pages are complete and readable.
+- The copy is aligned to the normalised briefing docs.
+- The page structure is simple enough to extend in phase 2 without a rewrite.

--- a/.github/projects/active/awesome-github-site/phase-2/README.md
+++ b/.github/projects/active/awesome-github-site/phase-2/README.md
@@ -6,6 +6,8 @@ version: "1.0.0"
 created_date: "2026-06-03"
 last_updated: "2026-06-03"
 status: active
+stability: stable
+domain: website
 owners:
   - Ash Shaw
 tags:

--- a/.github/projects/active/awesome-github-site/phase-2/README.md
+++ b/.github/projects/active/awesome-github-site/phase-2/README.md
@@ -1,0 +1,49 @@
+---
+file_type: documentation
+title: "Awesome GitHub Site - Phase 2"
+description: "Phase 2 plan for expanding the Awesome GitHub website into the full resource-style site."
+version: "1.0.0"
+created_date: "2026-06-03"
+last_updated: "2026-06-03"
+status: active
+owners:
+  - Ash Shaw
+tags:
+  - planning
+  - phase-2
+  - website
+  - expansion
+---
+
+# Phase 2
+
+## 3-Bullet Summary
+
+- Value: expands the MVP into the fuller resource-style site inspired by the reference structure.
+- Risks: bolting on category pages without a clean content model, search or discovery added too early, and inconsistent metadata across pages.
+- Next step: keep phase 2 dependent on the phase 1 foundation rather than designing it in isolation.
+
+## Scope
+
+Phase 2 adds the richer site structure:
+
+- resource catalogue pages
+- category browsing and navigation
+- supporting guides and discovery flows
+- stronger metadata and content organisation
+- fuller references and acknowledgements
+
+## Deliverables
+
+- Expanded information architecture
+- Reusable page patterns for resource pages
+- Search or browse-first discovery support
+- More comprehensive content and source coverage
+- Accessibility and visual polish for launch readiness
+
+## Acceptance Criteria
+
+- The phase 2 structure builds on the phase 1 MVP without replacing it.
+- Resource pages follow a consistent content model.
+- Navigation supports browsing by category and intent.
+- The site feels complete enough to stand beside the reference model without copying it directly.

--- a/.github/projects/active/next-issues-execution-plan.md
+++ b/.github/projects/active/next-issues-execution-plan.md
@@ -2,7 +2,7 @@
 title: Next Issues Execution Plan
 description: Comprehensive execution plan for all open issues, active projects, and
   strategic workflows.
-version: v2.2.3
+version: v2.2.4
 created_date: '2026-05-28'
 last_updated: '2026-06-03'
 file_type: documentation

--- a/.github/projects/active/next-issues-execution-plan.md
+++ b/.github/projects/active/next-issues-execution-plan.md
@@ -4,7 +4,7 @@ description: Comprehensive execution plan for all open issues, active projects, 
   strategic workflows.
 version: v2.2.3
 created_date: '2026-05-28'
-last_updated: '2026-06-01'
+last_updated: '2026-06-03'
 file_type: documentation
 maintainer: LightSpeed Team
 authors:
@@ -20,6 +20,14 @@ domain: governance
 stability: stable
 status: active
 ---
+
+## 2026-06-03 Awesome GitHub Site Planning Kickoff
+
+- New active project folder created: `.github/projects/active/awesome-github-site/`
+- Delivery is split into two phases:
+  - Phase 1: 1-3 page launchable MVP
+  - Phase 2: full resource-style site expansion
+- Source briefs were normalised into the project folder so the phase split can be planned without leaking talk-specific copy into the site plan.
 
 ## 2026-06-01 v0.5.0 Readiness Execution Update (Block 1)
 
@@ -163,6 +171,7 @@ GitHub Copilot is confirmed to continue the remaining Wave 2 implementation queu
 | --- | --- | --- | --- |
 | `github-workflow-consolidation-2026-05-28/` | ✅ COMPLETED - Epic #503 closed, planning docs ready for archive | GitHub Copilot | Archive to `completed/` folder after final review |
 | `launch-agents-checklist.md` | 🟡 IN PROGRESS - Partial test infrastructure fixes applied 2026-05-28 | LightSpeed Team | Complete remaining validation phases (critical pre-v1.0.0 release) |
+| `awesome-github-site/` | 🆕 NEW - Two-phase GitHub site programme with a launchable MVP first | Ash Shaw | Plan phase 1 and phase 2 issue chains; keep MVP small and source-backed |
 | `spec-only-agents-issue-conversion-2026-05-28.md` | ✅ COMPLETED - All spec-only agents converted to issues (#465, #467, #466, #468, #469) | GitHub Copilot | Archive to `completed/` folder |
 | `next-issues-execution-plan.md` | 📋 LIVING DOCUMENT - Updated 2026-05-29 with completion status and Wave 4C–4F allocation | Claude Code | Maintain and update continuously |
 | `ISSUE_33_BRANDING_AGENT_PARENT_SPEC.md` | ✅ COMPLETED - Issue #33 merged (planning phase) | Claude Code | Archive to `completed/` folder |

--- a/.github/projects/active/next-issues-execution-plan.md
+++ b/.github/projects/active/next-issues-execution-plan.md
@@ -282,7 +282,7 @@ README inventory: 44 files identified across the repo structure
 1. **Wave 3A: Discovery & Audit** ✅ CREATED (GitHub Copilot)
    - GitHub Issue: [#512 — Wave 3A: README & Mermaid Diagram Discovery & Audit](https://github.com/lightspeedwp/.github/issues/512)
    - Status: Ready for execution
-   - Workflow: [`.github/workflows/readme-audit.yml`](./.github/workflows/readme-audit.yml) created
+   - Workflow: [`.github/workflows/readme-audit.yml`](../../workflows/readme-audit.yml) created
    - Deliverables: Audit report, findings.csv, audit-log.md
    - Scope: Scan all 44 README files, extract Mermaid diagrams, categorize issues
    - Effort: 2-3 hours

--- a/.github/projects/active/next-issues-execution-plan.md
+++ b/.github/projects/active/next-issues-execution-plan.md
@@ -21,6 +21,8 @@ stability: stable
 status: active
 ---
 
+# Next Issues Execution Plan
+
 ## 2026-06-03 Awesome GitHub Site Planning Kickoff
 
 - New active project folder created: `.github/projects/active/awesome-github-site/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Awesome GitHub Site Planning Pack** — Created a new active project under `.github/projects/active/awesome-github-site/` with phase 1 and phase 2 planning docs, normalised briefing copies, and an updated execution tracker for the new GitHub-led website programme.
+
 ### Fixed
 
 - **v0.5.0 Readiness: Coverage and Reliability Gate Execution (`#746`, `#602`, `#599`, `#600`, `#601`)** — Re-activated planner/reviewer test coverage from skipped state into active Jest suites, added module-system consistency guards, and improved reviewer workflow dry-run support for safe validation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 title: "Changelog"
 description: "All notable changes to this project, formatted per Keep a Changelog 1.1.0 and Semantic Versioning"
 file_type: "documentation"
-version: "1.0.1"
+version: "1.0.2"
 created_date: "2025-09-20"
-last_updated: "2026-06-01"
+last_updated: "2026-06-03"
 owners:
   - LightSpeed Team
 tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -502,7 +502,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Branching Strategy](docs/BRANCHING_STRATEGY.md): Org-wide branch naming, merge discipline, and automation mapping.
 - [CHANGELOG.md](./CHANGELOG.md): Changelog format, release notes, and versioning.
 - [CONTRIBUTING.md](./CONTRIBUTING.md): Contribution guidelines, templates, coding standards.
-- [AUTOMATION_GOVERNANCE.md](docs/AUTOMATION_GOVERNANCE.md): Org-wide automation, branching, labelling, and release strategy.
-- [Org-wide Issue Labels](docs/ISSUE_LABELS.md): Default labels and usage guidance.
-- [Pull Request Labels](docs/PR_LABELS.md): PR classification and automation standards.
+- [AUTOMATION.md](docs/AUTOMATION.md): Org-wide automation, branching, labelling, and release strategy.
+- [LABELING.md](docs/LABELING.md): Default issue, PR, and discussion label guidance.
 - [Issue Types Guide](docs/ISSUE_TYPES.md): Classification and usage of issue types.

--- a/wceu-2026/website/mini-site-plan.md
+++ b/wceu-2026/website/mini-site-plan.md
@@ -3,6 +3,15 @@ title: "Mini Website Plan"
 description: "Information architecture and content requirements for a mini website explaining the WCEU 2026 talk."
 last_updated: "2026-06-02"
 owners: ["Ash Shaw"]
+file_type: plan
+version: "1.0.0"
+tags:
+  - planning
+  - website
+  - wceu-2026
+status: draft
+stability: draft
+domain: website
 ---
 
 # Mini Website Plan

--- a/wceu-2026/website/mini-site-plan.md
+++ b/wceu-2026/website/mini-site-plan.md
@@ -1,7 +1,8 @@
 ---
 title: "Mini Website Plan"
 description: "Information architecture and content requirements for a mini website explaining the WCEU 2026 talk."
-last_updated: "2026-06-02"owners: ["Ash Shaw"]
+last_updated: "2026-06-02"
+owners: ["Ash Shaw"]
 ---
 
 # Mini Website Plan

--- a/wceu-2026/website/page-copy-starter.md
+++ b/wceu-2026/website/page-copy-starter.md
@@ -3,6 +3,16 @@ title: "Page Copy Starter"
 description: "Draft copy scaffolding for mini website pages based on the talk narrative."
 last_updated: "2026-06-02"
 owners: ["Ash Shaw"]
+file_type: page
+version: "1.0.0"
+tags:
+  - planning
+  - copy
+  - website
+  - wceu-2026
+status: draft
+stability: draft
+domain: website
 ---
 
 # Page Copy Starter

--- a/wceu-2026/website/page-copy-starter.md
+++ b/wceu-2026/website/page-copy-starter.md
@@ -1,7 +1,8 @@
 ---
 title: "Page Copy Starter"
 description: "Draft copy scaffolding for mini website pages based on the talk narrative."
-last_updated: "2026-06-02"owners: ["Ash Shaw"]
+last_updated: "2026-06-02"
+owners: ["Ash Shaw"]
 ---
 
 # Page Copy Starter


### PR DESCRIPTION
## Summary

This PR creates the new `Awesome GitHub` planning pack under `.github/projects/active/awesome-github-site/` and updates the live execution tracker to reflect the two-phase delivery plan.

## Changelog

### Added
- New active project folder for `Awesome GitHub` planning.
- Phase 1 and Phase 2 planning docs.
- Normalised briefing copies and OpenSpec guidance.
- Updated active-project tracker entry for the new site programme.

### Changed
- Updated `.github/projects/active/next-issues-execution-plan.md` with the new project row and kickoff note.
- Normalised `wceu-2026/website/mini-site-plan.md` and `wceu-2026/website/page-copy-starter.md` frontmatter.
- Updated `CHANGELOG.md` references to the consolidated docs paths.

### Fixed
- Corrected a broken relative link in the active execution tracker so link validation passes.
- Fixed frontmatter freshness metadata for changed planning docs and changelog entries.

## Risk Assessment

Low. This is documentation and planning-only work. No runtime code, workflows, or production paths were changed. The main risk was link-validation breakage in repository documentation, which has been corrected.

## How to Test

- Run `npm test`.
- Confirm the changed markdown files parse cleanly and link targets resolve.
- Verify GitHub Actions passes for `lint-and-links` and `front-matter-validate`.

## Checklist

- [x] Planning docs added for phase 1 and phase 2
- [x] Active project tracker updated
- [x] Broken markdown links fixed
- [x] Frontmatter freshness metadata updated
- [x] Local tests passed
- [x] Branch pushed to origin
