### PR TITLE
chore(openspec): relocate change artifacts to active project path

### DIFF
--- a/.github/projects/active/openspec/README.md
+++ b/.github/projects/active/openspec/README.md
@@ -1,0 +1,35 @@
+---
+title: "OpenSpec Project Location"
+description: "Project-local guidance for storing OpenSpec changes under .github/projects/active while preserving CLI compatibility."
+file_type: "documentation"
+created_date: "2026-06-03"
+last_updated: "2026-06-03"
+version: "v1.0.0"
+authors: ["github-copilot"]
+tags: ["openspec", "opsx", "projects", "active"]
+---
+
+# OpenSpec Project Location
+
+This repository keeps OpenSpec change data inside the active project area:
+
+- `.github/projects/active/openspec/changes/...`
+
+To remain compatible with the OpenSpec CLI, the repository root path `openspec` is a symlink that points to:
+
+- `.github/projects/active/openspec`
+
+## Why this setup
+
+Current OpenSpec CLI configuration only supports global profile/workflow settings and does not expose a supported project-level key for overriding the changes directory.
+
+The symlink keeps CLI behaviour unchanged while storing project artefacts in the preferred active planning structure.
+
+## Operational notes
+
+1. Run OpenSpec commands from repository root as usual.
+2. New changes created by OpenSpec will resolve through the symlink and be written under `.github/projects/active/openspec/changes`.
+3. Keep the `openspec` symlink committed in git.
+4. If symlink drift occurs, recreate it from repository root:
+
+   `ln -sfn .github/projects/active/openspec openspec`

--- a/.github/projects/active/openspec/changes/agent-tool-permission-alignment/.openspec.yaml
+++ b/.github/projects/active/openspec/changes/agent-tool-permission-alignment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/.github/projects/active/openspec/changes/agent-tool-permission-alignment/design.md
+++ b/.github/projects/active/openspec/changes/agent-tool-permission-alignment/design.md
@@ -1,0 +1,69 @@
+## Context
+
+A repo-wide audit identified significant drift between agent specifications and the release-agent contract for tools and permissions. The drift includes zero-tool declarations, zero-permission declarations, partial permission sets, and ad hoc extra permissions. This creates inconsistent runtime behaviour and governance risk for MCP-mediated operations.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish one canonical, machine-checkable contract for `tools` and `permissions` in all agent specs.
+- Support controlled specialisation through named profiles (baseline plus variants), not ad hoc per-file drift.
+- Enforce compliance in CI and local workflows with actionable remediation output.
+
+**Non-Goals:**
+
+- Redesigning each agent's business logic or role definitions.
+- Migrating unrelated metadata fields in agent frontmatter.
+- Introducing a new external policy engine.
+
+## Decisions
+
+1. Contract source of truth
+
+- Decision: Use `agents/release.agent.md` as baseline and introduce a small profile registry for allowed variants.
+- Rationale: Existing organisational intent already uses release agent as model; this minimises policy ambiguity.
+- Alternative considered: infer profile from majority vote across all agents. Rejected due to existing drift and circularity.
+
+1. Validation mechanism
+
+- Decision: Implement validation as repository script plus CI gate.
+- Rationale: Deterministic checks, easy local reproduction, and immediate PR feedback.
+- Alternative considered: manual checklist-only enforcement. Rejected due to low reliability and review overhead.
+
+1. Policy expression model
+
+- Decision: Profile-based policy where each agent either matches baseline or an approved variant with explicit deltas.
+- Rationale: Allows legitimate specialisation while preventing undocumented divergence.
+- Alternative considered: hard force every agent to exact baseline. Rejected because some reviewers/planners need constrained scopes.
+
+1. Rollout strategy
+
+- Decision: Two-wave rollout: define validator and profiles first, then remediate agent files in batches by severity.
+- Rationale: Reduces blast radius and keeps CI failures actionable.
+- Alternative considered: one-shot remediation of all files. Rejected due to coordination risk.
+
+## Risks / Trade-offs
+
+- [Risk] Over-constraining specialised agents may block valid workflows. -> Mitigation: profile variants with explicit approved deltas.
+- [Risk] CI disruption during rollout if validator goes hard-fail too early. -> Mitigation: temporary warning mode for one cycle, then enforce.
+- [Risk] Profile drift returns over time. -> Mitigation: contract test in CI and documented update workflow for profile changes.
+- [Risk] Plugin-pack agents lag behind root agents. -> Mitigation: include plugin paths in the same validator target set and remediation report.
+
+## Migration Plan
+
+1. Create policy registry and validator script.
+2. Add local command and CI job (initial warning mode if needed).
+3. Apply fixes to critical agents first (zero tools/permissions), then high, then medium.
+4. Switch CI to hard-fail mode.
+5. Publish final compliance report and governance update notes.
+
+Rollback:
+
+- Revert validator workflow/job and policy files as one commit if widespread false positives occur.
+- Keep previously generated audit report to guide corrected reintroduction.
+
+## Open Questions
+
+- Should mode agents use constrained profiles by default, or baseline with explicit deny-list?
+- Should plugin-pack agent profiles be centrally inherited or locally overridden under strict constraints?
+- Should `github:issues` and `github:checks` be promoted to approved baseline extensions for specific agent classes?

--- a/.github/projects/active/openspec/changes/agent-tool-permission-alignment/proposal.md
+++ b/.github/projects/active/openspec/changes/agent-tool-permission-alignment/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Agent specifications in this repository are inconsistent in tool declarations and permissions, which causes unpredictable execution behaviour and weakens MCP security posture. We need a single enforceable contract based on the release agent model so all agents can execute safely and consistently.
+
+## What Changes
+
+- Define a canonical tool and permission contract for agent frontmatter, using `agents/release.agent.md` as the baseline profile.
+- Introduce profile tiers for specialised agents (for example reviewer-only, planning-only) while preserving required MCP and GitHub scopes for each tier.
+- Add automated validation that checks every `**/*.agent.md` file for required keys, allowed values, and profile compliance.
+- Add remediation guidance and migration rules for legacy mode and plugin agent files with zero or partial declarations.
+- Add CI enforcement so non-compliant agent specs fail validation before merge.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-tool-permission-contract`: Define and enforce a repo-wide contract for agent `tools` and `permissions`, including baseline profile, tiered variants, and automated validation rules.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected files: `agents/*.agent.md`, `plugins/**/agents/*.agent.md`, validation scripts under `.github/scripts` or `scripts`, and workflow validation jobs.
+- Affected systems: MCP tool access governance, GitHub workflow gates, and repository contribution rules.
+- Dependencies: existing lint/validation workflows and report generation conventions.

--- a/.github/projects/active/openspec/changes/agent-tool-permission-alignment/specs/agent-tool-permission-contract/spec.md
+++ b/.github/projects/active/openspec/changes/agent-tool-permission-alignment/specs/agent-tool-permission-contract/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Agent specifications SHALL declare explicit tool contracts
+
+Every agent specification file at `**/*.agent.md` MUST declare a `tools` field with one or more allowed tool identifiers.
+
+#### Scenario: Missing tools declaration is rejected
+
+- **WHEN** an agent file is validated and `tools` is missing or empty
+- **THEN** validation SHALL fail with a file-specific error explaining the missing declaration
+
+#### Scenario: Unsupported tool identifier is rejected
+
+- **WHEN** an agent file declares a tool identifier that is not in the allowed registry
+- **THEN** validation SHALL fail and list each unsupported identifier
+
+### Requirement: Agent specifications SHALL declare explicit permission contracts
+
+Every agent specification file at `**/*.agent.md` MUST declare a `permissions` field with one or more allowed permission identifiers.
+
+#### Scenario: Missing permissions declaration is rejected
+
+- **WHEN** an agent file is validated and `permissions` is missing or empty
+- **THEN** validation SHALL fail with a file-specific error explaining the missing declaration
+
+#### Scenario: Unsupported permission identifier is rejected
+
+- **WHEN** an agent file declares a permission identifier that is not in the allowed registry
+- **THEN** validation SHALL fail and list each unsupported identifier
+
+### Requirement: Baseline profile SHALL be defined and reusable
+
+The repository SHALL define a canonical baseline profile derived from `agents/release.agent.md` and allow named profile variants for specialised agents.
+
+#### Scenario: Baseline profile can be resolved
+
+- **WHEN** validation loads profile definitions
+- **THEN** the baseline profile SHALL resolve to a deterministic set of tools and permissions
+
+#### Scenario: Specialised profile references baseline extensions
+
+- **WHEN** a specialised profile is evaluated
+- **THEN** validation SHALL verify it either exactly matches baseline or documents explicit additive and subtractive differences
+
+### Requirement: Validation SHALL run in CI and local workflows
+
+Agent contract validation SHALL run in CI and SHALL be executable locally using a documented command.
+
+#### Scenario: CI blocks non-compliant changes
+
+- **WHEN** a pull request introduces non-compliant agent tool or permission declarations
+- **THEN** the CI validation job SHALL fail and prevent merge until resolved
+
+#### Scenario: Local validation mirrors CI behaviour
+
+- **WHEN** a contributor runs the local validation command
+- **THEN** it SHALL produce the same pass/fail outcome and error categories as CI for the same commit
+
+### Requirement: Validation output SHALL produce remediation guidance
+
+Validation failures SHALL include actionable remediation guidance and reference the expected profile contract.
+
+#### Scenario: Failure message includes remediation path
+
+- **WHEN** validation fails for an agent file
+- **THEN** output SHALL include missing keys, invalid entries, suggested profile, and next-step command to re-check

--- a/.github/projects/active/openspec/changes/agent-tool-permission-alignment/tasks.md
+++ b/.github/projects/active/openspec/changes/agent-tool-permission-alignment/tasks.md
@@ -1,0 +1,30 @@
+## 1. Policy Definition
+
+- [ ] 1.1 Define canonical baseline tool and permission profile from `agents/release.agent.md`.
+- [ ] 1.2 Define approved specialised profiles with explicit additive and subtractive deltas.
+- [ ] 1.3 Document allowed tool and permission registries in policy files.
+
+## 2. Validation Implementation
+
+- [ ] 2.1 Implement agent contract validator script for `**/*.agent.md`.
+- [ ] 2.2 Add validation output format with missing keys, invalid entries, and remediation hints.
+- [ ] 2.3 Add local command wiring in existing npm/script workflow.
+
+## 3. CI Integration
+
+- [ ] 3.1 Add validator execution to CI workflow for pull requests.
+- [ ] 3.2 Configure staged rollout mode (warn then fail) if required.
+- [ ] 3.3 Ensure CI output links to policy and remediation docs.
+
+## 4. Agent Remediation
+
+- [ ] 4.1 Remediate critical files (zero tools or zero permissions).
+- [ ] 4.2 Remediate high-severity files with missing MCP and GitHub permissions.
+- [ ] 4.3 Reconcile approved extra permissions (`github:issues`, `github:checks`) via explicit profile mapping.
+- [ ] 4.4 Remediate plugin-pack agent files to compliant profiles.
+
+## 5. Verification and Reporting
+
+- [ ] 5.1 Run validator across repository and confirm zero contract violations.
+- [ ] 5.2 Update audit report with post-remediation compliance summary.
+- [ ] 5.3 Record governance notes for future agent additions and profile-change process.

--- a/.github/reports/agents/agent-tools-permissions-mcp-audit-2026-06-02.md
+++ b/.github/reports/agents/agent-tools-permissions-mcp-audit-2026-06-02.md
@@ -1,0 +1,227 @@
+---
+title: "Agent Tools and MCP Permissions Audit"
+description: "Deep audit of all agent specifications against the release agent tools and permissions baseline, including MCP-related access posture."
+file_type: "report"
+category: "agents"
+created_date: "2026-06-02"
+last_updated: "2026-06-02"
+version: "v1.0.0"
+authors: ["github-copilot"]
+tags: ["agents", "audit", "mcp", "permissions", "tools"]
+---
+
+# Agent Tools and MCP Permissions Audit
+
+## Scope
+
+- Baseline: `agents/release.agent.md`
+- Population: all `**/*.agent.md` files in repository
+- Date: 2026-06-02
+
+## Baseline Contract (Release Agent)
+
+- Baseline tools count: 31
+- Baseline permissions count: 9
+- Baseline tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read, search, edit
+- Baseline permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+
+## Executive Summary
+
+- Total agent specs audited: 25
+- Exact baseline matches: 1
+- Non-matching specs: 24
+- Severity breakdown: critical=11, high=11, medium=2
+
+### Top Risk Findings
+
+- `10` agent specs define zero permissions.
+- `6` agent specs define zero tools.
+- Most-missing permissions: github:pulls(23), github:workflows(22), shell(22), github:actions(22), network(21), filesystem(16), github:repo(12), write(11), read(10)
+- Most-missing tools: github/*(13), read(12), contextual_accuracy_checker(12), timeliness_checker(12), connection_checker(12), file_system(12), markdown_generator(12), input_collector(12)
+
+## Detailed Matrix
+
+| Agent file | Severity | Tools | Permissions | Missing tools | Missing permissions | Extra tools | Extra permissions |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `agents/adr.agent.md` | critical | 27 | 0 | 4 | 9 | 0 | 0 |
+| `agents/issues.agent.md` | high | 31 | 4 | 0 | 6 | 0 | 1 |
+| `agents/labeling.agent.md` | high | 31 | 4 | 0 | 6 | 0 | 1 |
+| `agents/linting.agent.md` | medium | 31 | 7 | 0 | 2 | 0 | 0 |
+| `agents/meta.agent.md` | high | 31 | 4 | 0 | 5 | 0 | 0 |
+| `agents/metrics.agent.md` | high | 31 | 5 | 0 | 4 | 0 | 0 |
+| `agents/mode-demonstrate-understanding.agent.md` | critical | 0 | 0 | 31 | 9 | 0 | 0 |
+| `agents/mode-document-reviewer.agent.md` | high | 8 | 2 | 29 | 7 | 6 | 0 |
+| `agents/mode-prd.agent.md` | critical | 11 | 0 | 30 | 9 | 10 | 0 |
+| `agents/mode-thinking.agent.md` | high | 6 | 3 | 29 | 6 | 4 | 0 |
+| `agents/project-meta-sync.agent.md` | high | 31 | 6 | 0 | 4 | 0 | 1 |
+| `agents/prompt-engineer.agent.md` | high | 31 | 4 | 0 | 5 | 0 | 0 |
+| `agents/release.agent.md` | low | 31 | 9 | 0 | 0 | 0 | 0 |
+| `agents/reporting.agent.md` | high | 31 | 5 | 0 | 4 | 0 | 0 |
+| `agents/reviewer.agent.md` | high | 31 | 6 | 0 | 5 | 0 | 2 |
+| `agents/task-planner.agent.md` | high | 31 | 4 | 0 | 5 | 0 | 0 |
+| `agents/task-researcher.agent.md` | critical | 3 | 1 | 29 | 8 | 1 | 0 |
+| `agents/template.agent.md` | critical | 0 | 0 | 31 | 9 | 0 | 0 |
+| `agents/testing.agent.md` | medium | 31 | 7 | 0 | 2 | 0 | 0 |
+| `plugins/lightspeed-github-ops/agents/reviewer.agent.md` | critical | 0 | 0 | 31 | 9 | 0 | 0 |
+| `plugins/lightspeed-metrics-and-reporting/agents/metrics-reporting-orchestrator.agent.md` | critical | 0 | 0 | 31 | 9 | 0 | 0 |
+| `plugins/lightspeed-quality-assurance/agents/qa-orchestrator.agent.md` | critical | 0 | 0 | 31 | 9 | 0 | 0 |
+| `plugins/lightspeed-release-ops/agents/release-ops-orchestrator.agent.md` | critical | 0 | 0 | 31 | 9 | 0 | 0 |
+| `plugins/lightspeed-wordpress-governance/agents/wordpress-governance-reviewer.agent.md` | critical | 4 | 0 | 31 | 9 | 4 | 0 |
+| `plugins/lightspeed-wordpress-planning/agents/project-spec-orchestrator.agent.md` | critical | 4 | 0 | 31 | 9 | 4 | 0 |
+
+## Per-Agent Gap Details
+
+### `agents/adr.agent.md`
+
+- Severity: critical
+- Missing tools: github/*, read, search, edit
+- Missing permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+
+### `agents/issues.agent.md`
+
+- Severity: high
+- Missing permissions: filesystem, network, github:actions, github:workflows, github:pulls, shell
+- Extra permissions: github:issues
+
+### `agents/labeling.agent.md`
+
+- Severity: high
+- Missing permissions: filesystem, network, github:actions, github:workflows, github:pulls, shell
+- Extra permissions: github:issues
+
+### `agents/linting.agent.md`
+
+- Severity: medium
+- Missing permissions: network, github:pulls
+
+### `agents/meta.agent.md`
+
+- Severity: high
+- Missing permissions: network, github:actions, github:workflows, github:pulls, shell
+
+### `agents/metrics.agent.md`
+
+- Severity: high
+- Missing permissions: github:actions, github:workflows, github:pulls, shell
+
+### `agents/mode-demonstrate-understanding.agent.md`
+
+- Severity: critical
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read, search, edit
+- Missing permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+
+### `agents/mode-document-reviewer.agent.md`
+
+- Severity: high
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read
+- Missing permissions: filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+- Extra tools: shell, fetch, runTasks, githubRepo, todos, runSubagent
+
+### `agents/mode-prd.agent.md`
+
+- Severity: critical
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read, edit
+- Missing permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+- Extra tools: codebase, edit/editFiles, fetch, findTestFiles, list_issues, githubRepo, add_issue_comment, issue_write, issue_read, search_issues
+
+### `agents/mode-thinking.agent.md`
+
+- Severity: high
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read
+- Missing permissions: filesystem, network, github:actions, github:workflows, github:pulls, shell
+- Extra tools: codebase, fetch, bash, webSearch
+
+### `agents/project-meta-sync.agent.md`
+
+- Severity: high
+- Missing permissions: github:actions, github:workflows, github:pulls, shell
+- Extra permissions: github:issues
+
+### `agents/prompt-engineer.agent.md`
+
+- Severity: high
+- Missing permissions: network, github:actions, github:workflows, github:pulls, shell
+
+### `agents/reporting.agent.md`
+
+- Severity: high
+- Missing permissions: github:actions, github:workflows, github:pulls, shell
+
+### `agents/reviewer.agent.md`
+
+- Severity: high
+- Missing permissions: filesystem, network, github:actions, github:workflows, shell
+- Extra permissions: github:issues, github:checks
+
+### `agents/task-planner.agent.md`
+
+- Severity: high
+- Missing permissions: network, github:actions, github:workflows, github:pulls, shell
+
+### `agents/task-researcher.agent.md`
+
+- Severity: critical
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, edit
+- Missing permissions: write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+- Extra tools: fetch
+
+### `agents/template.agent.md`
+
+- Severity: critical
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read, search, edit
+- Missing permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+
+### `agents/testing.agent.md`
+
+- Severity: medium
+- Missing permissions: network, github:pulls
+
+### `plugins/lightspeed-github-ops/agents/reviewer.agent.md`
+
+- Severity: critical
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read, search, edit
+- Missing permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+
+### `plugins/lightspeed-metrics-and-reporting/agents/metrics-reporting-orchestrator.agent.md`
+
+- Severity: critical
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read, search, edit
+- Missing permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+
+### `plugins/lightspeed-quality-assurance/agents/qa-orchestrator.agent.md`
+
+- Severity: critical
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read, search, edit
+- Missing permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+
+### `plugins/lightspeed-release-ops/agents/release-ops-orchestrator.agent.md`
+
+- Severity: critical
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read, search, edit
+- Missing permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+
+### `plugins/lightspeed-wordpress-governance/agents/wordpress-governance-reviewer.agent.md`
+
+- Severity: critical
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read, search, edit
+- Missing permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+- Extra tools: runTests, file_search, read_file, grep_search
+
+### `plugins/lightspeed-wordpress-planning/agents/project-spec-orchestrator.agent.md`
+
+- Severity: critical
+- Missing tools: file_system, markdown_generator, input_collector, adr_naming_helper, quality_checker, template_filler, context_analyzer, decision_rationale_extractor, alternative_evaluator, consequence_analyzer, implementation_planner, reference_manager, date_manager, stakeholder_identifier, status_manager, tag_manager, supersession_tracker, yaml_front_matter_generator, markdown_saver, language_enforcer, structure_enforcer, completeness_verifier, clarity_checker, consistency_checker, timeliness_checker, connection_checker, contextual_accuracy_checker, github/*, read, search, edit
+- Missing permissions: read, write, filesystem, network, github:repo, github:actions, github:workflows, github:pulls, shell
+- Extra tools: runTests, file_search, read_file, grep_search
+
+## Audit Conclusion
+
+- The release agent is the only exact match to the target contract.
+- Tool definitions are generally aligned in core agents, but permissions are inconsistently under-scoped.
+- Several mode/template/plugin agents have little or no declared tools/permissions and require contract hardening before MCP-reliant execution.
+
+## Recommended Remediation Waves
+
+1. Critical: add full baseline permissions to zero-permission agents and zero-tool agents where they are expected to execute.
+2. High: normalise missing `github:actions`, `github:workflows`, `github:pulls`, `shell`, `network` permissions across orchestrator agents.
+3. Medium: reconcile intentional extras (for example `github:issues`, `github:checks`) into a documented superset policy.

--- a/audit_script.rb
+++ b/audit_script.rb
@@ -1,0 +1,46 @@
+require 'yaml'
+require 'pathname'
+
+def frontmatter(path)
+  txt = File.read(path)
+  return nil unless txt.start_with?("---\n")
+  parts = txt.split(/^---\s*$/\n?, 3)
+  yaml = parts[1]
+  YAML.safe_load(yaml, permitted_classes: [Date, Time], aliases: true)
+rescue => e
+  {"__error"=>e.message}
+end
+
+files = Dir['agents/*.agent.md'].sort
+baseline = frontmatter('agents/release.agent.md') || {}
+base_tools = Array(baseline['tools']).map(&:to_s)
+base_perms = Array(baseline['permissions']).map(&:to_s)
+puts "BASELINE: release.agent.md"
+puts "tools(#{base_tools.size}): #{base_tools.join(', ')}"
+puts "permissions(#{base_perms.size}): #{base_perms.join(', ')}"
+puts "\nAGENT AUDIT"
+files.each do |f|
+  fm = frontmatter(f)
+  if fm.nil?
+    puts "\n#{f}: ERROR no frontmatter"
+    next
+  end
+  if fm['__error']
+    puts "\n#{f}: ERROR parsing frontmatter: #{fm['__error']}"
+    next
+  end
+  tools = Array(fm['tools']).map(&:to_s)
+  perms = Array(fm['permissions']).map(&:to_s)
+  miss_t = base_tools - tools
+  miss_p = base_perms - perms
+  extra_t = tools - base_tools
+  extra_p = perms - base_perms
+  puts "\n#{f}"
+  puts "  tools_present=#{fm.key?('tools')} count=#{tools.size}"
+  puts "  permissions_present=#{fm.key?('permissions')} count=#{perms.size}"
+  puts "  missing_tools(#{miss_t.size}): #{miss_t.join(', ')}" unless miss_t.empty?
+  puts "  missing_permissions(#{miss_p.size}): #{miss_p.join(', ')}" unless miss_p.empty?
+  puts "  extra_tools(#{extra_t.size}): #{extra_t.join(', ')}" unless extra_t.empty?
+  puts "  extra_permissions(#{extra_p.size}): #{extra_p.join(', ')}" unless extra_p.empty?
+  puts "  status: #{miss_t.empty? && miss_p.empty? ? 'MATCH_BASELINE' : 'GAP'}"
+end

--- a/openspec
+++ b/openspec
@@ -1,0 +1,1 @@
+.github/projects/active/openspec


### PR DESCRIPTION
## Summary
- relocate OpenSpec change artifacts into `.github/projects/active/openspec/changes`
- preserve OpenSpec CLI compatibility with root `openspec` symlink pointing to `.github/projects/active/openspec`
- add project-local guidance for this path strategy

## Why
- keep active planning artifacts within the existing `.github/projects/active` structure
- maintain compatibility with current OpenSpec CLI behaviour, which expects an `openspec` path at repository root

## Included Changes
- `.github/projects/active/openspec/README.md`
- `.github/projects/active/openspec/changes/agent-tool-permission-alignment/.openspec.yaml`
- `.github/projects/active/openspec/changes/agent-tool-permission-alignment/proposal.md`
- `.github/projects/active/openspec/changes/agent-tool-permission-alignment/design.md`
- `.github/projects/active/openspec/changes/agent-tool-permission-alignment/specs/agent-tool-permission-contract/spec.md`
- `.github/projects/active/openspec/changes/agent-tool-permission-alignment/tasks.md`
- `openspec` symlink

## Validation
- `opsx list` resolves the moved change
- `opsx validate agent-tool-permission-alignment` passes
- merge marker scan is clean (`^<<<<<<<|^=======|^>>>>>>>`)

## Labels
- `type:chore`
- `status:needs-review`
- `meta:no-changelog`
