### PR TITLE
docs: enforce AI governance & branching strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: "Changelog"
 description: "All notable changes to this project, formatted per Keep a Changelog 1.1.0 and Semantic Versioning"
 file_type: "documentation"
-version: "1.0.4"
+version: "1.0.5"
 created_date: "2025-09-20"
 last_updated: "2026-06-03"
 owners:
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AI Governance & Branch Protection Enforcement** — Added comprehensive AI governance rules to `CLAUDE.md` with explicit branch naming enforcement (`{type}/{scope}-{short-title}` format, no `claude/` prefixes), clarification that explicit user instructions must be executed immediately without reinterpretation, and main branch protection policies for release cycles only.
 - **Awesome GitHub Site Planning Pack** — Created a new active project under `.github/projects/active/awesome-github-site/` with phase 1 and phase 2 planning docs, normalised briefing copies, and an updated execution tracker for the new GitHub-led website programme.
 - **Awesome GitHub Site GitHub Pages Implementation** — Added the Astro phase 1 site scaffold, GitHub Pages deployment workflow, custom `404` page, canonical `github.lightspeedwp.agency` domain support, and review-driven fixes for frontmatter, motion, and package metadata.
 - **WCEU 2026 Conference Site Expansion** — Expanded the public site into a conference-ready talk hub with per-slide pages, updated navigation and footer elements, a light/dark mode switcher, and GitHub Pages-safe slide parsing dependencies for CI builds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,10 @@ Do **not** place reusable assets under `.github/`—use the matching top-level f
 #### Branch Naming — NO "claude/" Prefix
 
 - **FORBIDDEN:** Do NOT use `claude/` as a branch prefix. This is not permitted under any circumstance.
-- **REQUIRED:** ALL branches must follow the format: `{type}/{scope}-{short-title}` where `{type}` is one of: `feat/`, `fix/`, `hotfix/`, `chore/`, `docs/`, `ci/`, `test/`, `refactor/`, `security/`, `release/`.
-- **ENFORCEMENT:** If you create a branch with `claude/` prefix, it violates this policy. Use the correct prefix instead.
+- **REQUIRED:** ALL branches must follow the format: `{type}/{scope}-{short-title}` (lowercase, kebab-case) where `{type}` is one of the core prefixes listed below.
+- **CORE PREFIXES:** `feat/`, `fix/`, `hotfix/`, `release/`, `refactor/`, `chore/`, `docs/`, `test/`, `perf/`, `ci/`, `build/`, `deps/`, `security/`, `revert/`, `research/`, `design/`, `a11y/`, `ux/`, `i18n/`, `ops/`.
+- **ADDITIONAL PREFIXES:** [docs/BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md) documents optional product-specific (`proto/`, `ds/`, `api/`, `schema/`, `telemetry/`) and client-specific (`content/`, `seo/`, `config/`, `migrate/`, `qa/`) prefixes.
+- **ENFORCEMENT:** If you create a branch with `claude/` prefix or any non-standard prefix, it violates this policy. Use an appropriate prefix from the authoritative strategy document.
 - **AUTHORITATIVE SOURCE:** [docs/BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md) is the canonical reference for all branching rules.
 
 #### Explicit User Instructions — EXECUTE IMMEDIATELY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 ---
 title: "LightSpeed .github — Claude Instructions"
 description: "Claude-specific project instructions for the LightSpeed .github repository."
-version: "v1.2"
-last_updated: "2026-06-01"
+version: "v1.3"
+last_updated: "2026-06-03"
 file_type: "agents-index"
 maintainer: "LightSpeed Team"
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,14 +44,14 @@ Do **not** place reusable assets under `.github/`—use the matching top-level f
 
 > **CRITICAL:** This repository follows a strict branching discipline. Read [docs/BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md) before opening any PR.
 
-### AI Governance & Branch Protection (LASTING FIX)
+### AI Governance & Branch Protection
 
-**This section exists to prevent future violations. Follow these rules without exception.**
+**Follow these rules without exception.**
 
 #### Branch Naming — NO "claude/" Prefix
 
 - **FORBIDDEN:** Do NOT use `claude/` as a branch prefix. This is not permitted under any circumstance.
-- **REQUIRED:** ALL branches must follow the format: `{type}/{scope}-{short-title}` where `{type}` is one of: `feat/`, `fix/`, `hotfix/`, `chore/`, `docs/`, `ci/`, `test/`, `refactor/`, `security/`.
+- **REQUIRED:** ALL branches must follow the format: `{type}/{scope}-{short-title}` where `{type}` is one of: `feat/`, `fix/`, `hotfix/`, `chore/`, `docs/`, `ci/`, `test/`, `refactor/`, `security/`, `release/`.
 - **ENFORCEMENT:** If you create a branch with `claude/` prefix, it violates this policy. Use the correct prefix instead.
 - **AUTHORITATIVE SOURCE:** [docs/BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md) is the canonical reference for all branching rules.
 
@@ -70,7 +70,7 @@ Do **not** place reusable assets under `.github/`—use the matching top-level f
 
 - Never push to `main` outside of release cycles (tagging release versions).
 - Only user-initiated merges (via explicit instruction like "merge to main") trigger main branch changes during releases.
-- `develop` is the integration branch for all non-release work.
+- `develop` (if used) is the integration branch for all non-release work.
 
 ### Protected Branches
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,34 @@ Do **not** place reusable assets under `.github/`—use the matching top-level f
 
 > **CRITICAL:** This repository follows a strict branching discipline. Read [docs/BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md) before opening any PR.
 
+### AI Governance & Branch Protection (LASTING FIX)
+
+**This section exists to prevent future violations. Follow these rules without exception.**
+
+#### Branch Naming — NO "claude/" Prefix
+
+- **FORBIDDEN:** Do NOT use `claude/` as a branch prefix. This is not permitted under any circumstance.
+- **REQUIRED:** ALL branches must follow the format: `{type}/{scope}-{short-title}` where `{type}` is one of: `feat/`, `fix/`, `hotfix/`, `chore/`, `docs/`, `ci/`, `test/`, `refactor/`, `security/`.
+- **ENFORCEMENT:** If you create a branch with `claude/` prefix, it violates this policy. Use the correct prefix instead.
+- **AUTHORITATIVE SOURCE:** [docs/BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md) is the canonical reference for all branching rules.
+
+#### Explicit User Instructions — EXECUTE IMMEDIATELY
+
+- When the user explicitly instructs you to perform an action (e.g., "merge to develop", "push this branch", "create PR and merge"), **execute the instruction immediately**. Do not reinterpret, second-guess, or apply additional governance layers.
+- **Example:** If user says "create a PR for branch X and merge into develop", you MUST:
+  1. Create the PR
+  2. Wait for checks to pass
+  3. Merge into develop
+  4. Report completion
+  Do NOT hold back due to governance concerns or ask for re-approval.
+- **Rationale:** User instructions are explicit authorisation. AI governance rules protect against accidental violations, not against explicit user intent.
+
+#### main Branch — Release Only
+
+- Never push to `main` outside of release cycles (tagging release versions).
+- Only user-initiated merges (via explicit instruction like "merge to main") trigger main branch changes during releases.
+- `develop` is the integration branch for all non-release work.
+
 ### Protected Branches
 
 - `main` is **always production-ready**. Never push directly to `main` unless performing a **release cycle**.


### PR DESCRIPTION
## Summary

Critical governance fix to CLAUDE.md that enforces the documented branching strategy and clarifies AI behavior around explicit user instructions.

## Changes

- Added **AI Governance & Branch Protection** section to CLAUDE.md
- Explicitly forbids use of `claude/` prefix for branch names
- Clarifies that ALL branches must follow `{type}/{scope}-{short-title}` format from docs/BRANCHING_STRATEGY.md
- Establishes that explicit user instructions (e.g., "merge to develop") must be executed immediately without reinterpretation or governance gates

## Why This Matters

This prevents recurrence of:
1. Branch naming violations (claude/ prefix usage)
2. Misapplication of governance rules that prevent explicit user instructions from being executed

This is a "lasting fix" to ensure AI governance protects against accidental violations, not against explicit user intent.

## Testing

- [x] Branch name follows strategy: `docs/enforce-branching-strategy`
- [x] CLAUDE.md validates and renders correctly
- [x] References to docs/BRANCHING_STRATEGY.md are accurate
- [x] All governance rules are unambiguous and actionable

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9nKgG6do1jaoEDRL2wFDQ)_