### PR TITLE
fix(ci): make PR template heading checks multiline-aware

### DIFF
--- a/.github/workflows/template-enforcement.yml
+++ b/.github/workflows/template-enforcement.yml
@@ -110,8 +110,8 @@ jobs:
             const body = (pr.body || '').trim();
 
             const required = [
-              { name: 'Linked issues', regex: /^##\s+Linked issues/i },
-              { name: 'Changelog', regex: /^##\s+Changelog/i },
+              { name: 'Linked issues', regex: /^##\s+Linked issues/im },
+              { name: 'Changelog', regex: /^##\s+Changelog/im },
               { name: 'Global DoD checklist', regex: /^###\s+Checklist\s+\(Global DoD\s*\/\s*PR\)/im }
             ];
 


### PR DESCRIPTION
## Linked issues

- N/A

## Changelog

- No changelog entry required (workflow guardrail fix only).

## Summary

Fix template enforcement regex matching so required PR headings are detected anywhere in the body (multiline mode), matching real template structure.

### Checklist (Global DoD / PR)

- [x] Scoped fix to one workflow file
- [x] Workflow lint passes locally
- [x] No runtime product code changed
