### PR TITLE
[fix] align required template checks with PR workflow

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -31,7 +31,9 @@ This directory contains version-controlled JSON definitions of the GitHub reposi
   - Deletion blocked
   - Non-fast-forward merges (force pushes) blocked
   - Pull request required before merging (1 approval, dismiss stale approvals, resolve conversations, respect Code Owners)
-  - Required status check: `All Checks Passed`
+  - Required status checks:
+    - `Validate PR Template / validate-pr-template`
+    - `CI • Unified Checks (Lint, Test, Validate) / All Checks Passed`
 
 ### 2. `main` Branch Ruleset ([main.ruleset.json](./main.ruleset.json))
 

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -2,10 +2,10 @@
 file_type: documentation
 title: GitHub Branch Rulesets Configuration
 description: Overview and instructions for importing/updating the repository branch rulesets.
-last_updated: '2026-06-08'
+last_updated: '2026-06-18'
 owners:
   - LightSpeed Team
-version: v1.0
+version: v1.1
 status: active
 stability: stable
 domain: governance

--- a/.github/rulesets/develop.ruleset.json
+++ b/.github/rulesets/develop.ruleset.json
@@ -31,7 +31,10 @@
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
           {
-            "context": "All Checks Passed"
+            "context": "Validate PR Template / validate-pr-template"
+          },
+          {
+            "context": "CI • Unified Checks (Lint, Test, Validate) / All Checks Passed"
           }
         ]
       }


### PR DESCRIPTION
## What changed
- Updated the `develop` ruleset to require the actual PR validation workflow, `Validate PR Template / validate-pr-template`.
- Kept `CI • Unified Checks (Lint, Test, Validate) / All Checks Passed` as the CI gate.
- Synced the ruleset documentation to match the enforced contexts.

## Linked issues
- Relates to #898

## Changelog
### Added
- None.

### Changed
- Corrected the required status checks on `develop` to use the PR-time template validation workflow.
- Updated the ruleset documentation so the declared checks match the live branch protection.

### Fixed
- Resolved the branch-protection mismatch that was blocking Mergify on a check that never ran for PRs.

### Removed
- None.

### Checklist (Global DoD / PR)
- [x] All AC met and demonstrated
- [x] Tests added/updated (not required for ruleset-only change)
- [x] Docs/readme/changelog updated (if user-facing)
- [x] CI green; linked issues closed; release notes prepared (if shipping)

## Validation
- `gh api repos/lightspeedwp/.github/branches/develop/protection/required_status_checks`
- `jq empty .github/rulesets/develop.ruleset.json`
- `npm run validate:branch-name -- --branch fix/template-check-contexts`
