### PR TITLE
Update README.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -46,9 +46,10 @@ For advanced usage, see the [Issue Template Index](./README.md) and individual t
 ## 🗂️ Issue Template Workflow
 
 ```mermaid
-accTitle: Issue template workflow
-accDescr: Shows how users select an issue template, auto-populated fields flow into issue creation, and automation routes the issue to labelling, project, and notification steps.
 flowchart TD
+    accTitle: Issue template workflow
+    accDescr: Shows how users select an issue template, auto-populated fields flow into issue creation, and automation routes the issue to labelling, project, and notification steps.
+
     A[User Creates Issue] --> B{Select Template}
     B -->|Bug Report| C[Bug Template]
     B -->|Feature Request| D[Feature Template]


### PR DESCRIPTION
## Summary

Fix Mermaid diagram syntax that was preventing the flowchart from rendering in
`.github/ISSUE_TEMPLATE/README.md`.

The `accTitle` and `accDescr` directives were placed outside the flowchart block,
which is invalid MMD syntax. Moved them inside the `flowchart TD` block and added
a trailing newline for clarity.

## Root Cause

Mermaid requires `accTitle` and `accDescr` to appear as the first statements
*inside* the diagram type declaration (e.g. `flowchart TD`), not before it.
Placing them outside caused the entire diagram to fail to render.

## Changes

- `.github/ISSUE_TEMPLATE/README.md` — moved `accTitle` and `accDescr` inside
  the `flowchart TD` block; added blank line after directives.

## Risk Assessment

**Risk Level:** Low

**Potential Impact:** Documentation-only change; no functional code affected.

**Mitigation Steps:** Change is a direct syntax correction with no logic involved.

## How to Test

1. Open `.github/ISSUE_TEMPLATE/README.md` on the branch in GitHub's preview.
2. Confirm the Mermaid flowchart renders correctly (issue template workflow diagram).
3. Confirm no regressions in surrounding markdown formatting.

## Changelog

### Fixed

- Mermaid `accTitle`/`accDescr` directives repositioned inside `flowchart TD`
  block to restore diagram rendering in the Issue Template README.

Closes #