### PR TITLE
fix(ci): auto-approve dependabot PRs so Mergify can squash-merge them

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -18,7 +18,8 @@ pull_request_rules:
       - -draft
       - -conflict
     actions:
-      approve:
+      review:
+        type: APPROVE
       queue:
         name: dependabot
   - name: Keep imgbot image optimizations current on develop
@@ -54,7 +55,6 @@ queue_rules:
       - check-success=All Checks Passed
     merge_method: squash
     batch_size: 1
-    allow_checks_interruption: false
   - name: Merge queue
     batch_size: 1
 merge_queue:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,28 +9,16 @@ pull_request_rules:
       - "#commits-behind > 0"
     actions:
       update:
-  - name: Auto-merge Dependabot dependency updates on develop
+  - name: Auto-approve and merge Dependabot dependency updates on develop
     conditions:
       - author~=^(dependabot\[bot\]|app/dependabot)$
       - base=develop
       - label=area:dependencies
-      - -label=meta:dependabot-security
       - check-success=All Checks Passed
       - -draft
       - -conflict
     actions:
-      queue:
-        name: dependabot
-  - name: Auto-merge Dependabot security updates on develop
-    conditions:
-      - author~=^(dependabot\[bot\]|app/dependabot)$
-      - base=develop
-      - label=area:dependencies
-      - label=meta:dependabot-security
-      - check-success=All Checks Passed
-      - -draft
-      - -conflict
-    actions:
+      approve:
       queue:
         name: dependabot
   - name: Keep imgbot image optimizations current on develop
@@ -66,6 +54,7 @@ queue_rules:
       - check-success=All Checks Passed
     merge_method: squash
     batch_size: 1
+    allow_checks_interruption: false
   - name: Merge queue
     batch_size: 1
 merge_queue:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,77 @@
+name: Dependabot Auto-Merge
+
+on:
+  workflow_run:
+    workflows: ["CI • Unified Checks (Lint, Test, Validate)"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    # Only act when CI passed and the run was triggered by a dependabot pull_request event.
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve and enable auto-merge for dependabot PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prs = context.payload.workflow_run.pull_requests || [];
+
+            for (const pr of prs) {
+              if (pr.base.ref !== 'develop') {
+                core.info(`PR #${pr.number} targets ${pr.base.ref} — skipping.`);
+                continue;
+              }
+
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner, repo, pull_number: pr.number,
+              });
+
+              if (pullRequest.state !== 'open') {
+                core.info(`PR #${pr.number} is ${pullRequest.state} — skipping.`);
+                continue;
+              }
+              if (pullRequest.draft) {
+                core.info(`PR #${pr.number} is a draft — skipping.`);
+                continue;
+              }
+
+              // Approve (satisfies branch-protection review requirement).
+              try {
+                await github.rest.pulls.createReview({
+                  owner, repo,
+                  pull_number: pr.number,
+                  event: 'APPROVE',
+                  body: 'Auto-approved: dependabot dependency update with all CI checks passing.',
+                });
+                core.info(`Approved PR #${pr.number}.`);
+              } catch (err) {
+                core.info(`Approval for PR #${pr.number} skipped (may already be approved): ${err.message}`);
+              }
+
+              // Enable squash auto-merge via GraphQL.
+              try {
+                await github.graphql(`
+                  mutation($id: ID!) {
+                    enablePullRequestAutoMerge(input: {
+                      pullRequestId: $id,
+                      mergeMethod: SQUASH
+                    }) {
+                      pullRequest { number autoMergeRequest { enabledAt } }
+                    }
+                  }
+                `, { id: pullRequest.node_id });
+                core.info(`Auto-merge (squash) enabled for PR #${pr.number}.`);
+              } catch (err) {
+                core.info(`Auto-merge for PR #${pr.number} failed: ${err.message}`);
+              }
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dependabot auto-merge unblocked** — Fixed Mergify configuration that prevented all dependabot PRs from being automatically merged: consolidated the redundant security/non-security rules into one, replaced the invalid `approve:` action with `review: type: APPROVE` (which satisfies branch-protection review requirements), and added a `dependabot-automerge.yml` GitHub Actions backup workflow that approves and enables squash auto-merge via `workflow_run` when CI passes on a dependabot PR. ([#1020](https://github.com/lightspeedwp/.github/pull/1020), relates to [#968](https://github.com/lightspeedwp/.github/issues/968))
+
 - **Release agent hardening** — Fixed four bugs in `scripts/agents/release.agent.js`: (1) regex escape `\\d+` → `\d+` in `getMergedPRs` so PR numbers are correctly extracted from `git log`; (2) automated release PR body now includes all three sections (`## Linked issues & merged PRs`, `## Changelog`, `### Checklist (Global DoD / PR)`) required by the main-branch-guard; (3) `createReleasePR` (shell provider) now writes the body to a temp file and uses `--body-file` to avoid shell injection from backtick-containing markdown; (4) corrected Husky v9 command from `npx husky run pre-commit` to `npx lint-staged`. Added full test suites for `changelogUtils.cjs`, `validate-main-branch-pr.cjs`, and `release.agent.js` (ESM subprocess pattern); rewrote the stub in `validate-changelog.test.js` with real CLI and integration tests. Clarified the `develop → release/vX.Y.Z → main` flow in the release issue template. ([#1018](https://github.com/lightspeedwp/.github/pull/1018), [#968](https://github.com/lightspeedwp/.github/issues/968))
 
 ### Changed


### PR DESCRIPTION
## Linked issues

relates to #968

## Summary

- **Root cause 1 — No auto-approval**: Mergify's rules had no approval action. Branch protection on `develop` requires ≥1 approved review; without an approval Mergify's queue can never complete the squash-merge.
- **Root cause 2 — Wrong Mergify action name**: `approve:` is not a valid Mergify action. The correct action is `review: type: APPROVE`.
- **Root cause 3 — Redundant security/non-security split**: `dependabot-security-label.yml` applies `meta:dependabot-security` to virtually every dependabot PR via the broad `/\bto fix\b/i` pattern. Both rules queued to the same `dependabot` queue anyway, so they are merged into one.
- **Belt-and-suspenders — GitHub Actions backup**: A new `dependabot-automerge.yml` workflow triggers via `workflow_run` when CI passes on a dependabot PR, independently approves the PR, and enables GitHub's native squash auto-merge.

## Changelog

- Fix Mergify config: replace invalid `approve:` with `review: type: APPROVE`
- Fix Mergify config: consolidate two dependabot rules into one
- Add `dependabot-automerge.yml` workflow: auto-approve + enable squash auto-merge when CI passes on dependabot PRs

### Checklist (Global DoD / PR)

- [x] Changes are limited to the described fix
- [x] Branch name follows `{type}/{scope}-{title}` convention
- [x] YAML lints clean (`spectral lint`)
- [x] Branch name validator passes
- [x] CHANGELOG.md updated
- [x] No secrets or credentials committed