### PR TITLE
chore(ci): enable reliable mergify auto-merge for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,3 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - area:dependencies
-      - github-actions

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,8 @@
+queue_rules:
+  - name: dependabot-develop
+    merge_method: squash
+    speculative_checks: 1
+
 pull_request_rules:
   # Keep Dependabot PRs up-to-date by rebasing if develop has moved ahead
   - name: Keep Dependabot dependency updates on develop current
@@ -11,8 +16,8 @@ pull_request_rules:
     actions:
       update: {}
 
-  # Auto-approve and merge Dependabot dependency updates when CI passes
-  - name: Auto-approve and merge Dependabot dependency updates on develop
+  # Auto-approve and queue Dependabot dependency updates when CI passes
+  - name: Auto-approve and queue Dependabot dependency updates on develop
     conditions:
       - author~=^(dependabot\[bot\]|app/dependabot)$
       - base=develop
@@ -23,8 +28,8 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
-      merge:
-        method: squash
+      queue:
+        name: dependabot-develop
 
   # Keep imgbot image optimizations up-to-date by rebasing if develop has moved ahead
   - name: Keep imgbot image optimizations current on develop


### PR DESCRIPTION
## Linked issues
- relates to #1048
- relates to #1049
- relates to #1050
- relates to #1051
- relates to #1052
- relates to #1053
- relates to #1056

## Changelog
- Updated Mergify rules to queue and auto-approve Dependabot PRs on develop after required checks pass.
- Removed invalid `github-actions` label from Dependabot config to prevent update failures caused by a missing label.

### Checklist (Global DoD / PR)
- [x] Scope is limited to Dependabot/Mergify automation config.
- [x] YAML validation completed (`npm run lint:yaml`).
- [x] Mergify commands were issued on currently open Dependabot PRs (`queue` and `update` where needed).
