### PR TITLE
fix(ci): replace silent reopening with guidance comment and label

### DIFF
--- a/.github/workflows/template-enforcement.yml
+++ b/.github/workflows/template-enforcement.yml
@@ -220,6 +220,21 @@ jobs:
 
             if (missingSections.length === 0 && !hasNeedsMoreInfo) {
               core.info(`Issue #${issue.number} meets close requirements.`);
+
+              // Remove status:needs-template-fix label if present (issue is now compliant)
+              const currentLabels = new Set((issue.labels || []).map((label) => label.name));
+              if (currentLabels.has('status:needs-template-fix')) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: 'status:needs-template-fix',
+                  });
+                } catch (error) {
+                  core.info(`Unable to remove status:needs-template-fix from #${issue.number}: ${error.message}`);
+                }
+              }
               return;
             }
 
@@ -240,10 +255,11 @@ jobs:
               ...reasons.map((r) => `- ${r}`),
               '',
               '**What you can do:**',
-              '1. **Fix the issue:** Update the issue body with the correct template sections',
-              '2. **Reopen it:** Comment to reopen, or use the "Reopen issue" button',
-              '3. **Force close:** Add the `meta:force-close` label if closure is necessary despite incomplete requirements',
+              '1. **Fix the issue:** Edit this issue and update the body with the correct template sections (DoR and DoD sections)',
+              '2. **Reopen it:** Click the "Reopen issue" button on this page to reopen after fixing',
+              '3. **Force close:** Add the `meta:force-close` label to this issue if closure is necessary despite incomplete requirements',
               '',
+              '**After fixing:** The issue will no longer show this warning and can be closed normally.',
               '**Need help?** See the issue template guide: https://github.com/lightspeedwp/.github/issues/new/choose',
             ].join('\n');
 

--- a/.github/workflows/template-enforcement.yml
+++ b/.github/workflows/template-enforcement.yml
@@ -182,6 +182,16 @@ jobs:
               return;
             }
 
+            // Check for force-close override
+            const hasForceClose = (issue.labels || []).some(
+              (label) => label.name === 'meta:force-close'
+            );
+
+            if (hasForceClose) {
+              core.info(`Issue #${issue.number} has meta:force-close label; allowing close despite incomplete requirements.`);
+              return;
+            }
+
             const author = issue.user?.login || '';
             const isBot = issue.user?.type === 'Bot' ||
               author === 'dependabot[bot]' ||
@@ -213,13 +223,7 @@ jobs:
               return;
             }
 
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              state: 'open',
-            });
-
+            // Issue has incomplete requirements. Post guidance comment and add label (don't reopen).
             const reasons = [];
             if (missingSections.length > 0) {
               reasons.push(`Missing required section(s): ${missingSections.join(', ')}`);
@@ -230,12 +234,17 @@ jobs:
 
             const message = [
               marker,
-              '🔄 This issue was automatically re-opened because it does not meet the close requirements.',
+              '⚠️ This issue was closed but does not meet our completion requirements.',
               '',
+              '**Issues preventing closure:**',
               ...reasons.map((r) => `- ${r}`),
               '',
-              'Please resolve the above, update the issue body with the correct template, then close again.',
-              '- Template guide: https://github.com/lightspeedwp/.github/issues/new/choose',
+              '**What you can do:**',
+              '1. **Fix the issue:** Update the issue body with the correct template sections',
+              '2. **Reopen it:** Comment to reopen, or use the "Reopen issue" button',
+              '3. **Force close:** Add the `meta:force-close` label if closure is necessary despite incomplete requirements',
+              '',
+              '**Need help?** See the issue template guide: https://github.com/lightspeedwp/.github/issues/new/choose',
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -265,7 +274,18 @@ jobs:
               });
             }
 
-            core.setFailed(`Issue #${issue.number} re-opened: does not meet close requirements (${reasons.join('; ')}).`);
+            // Add status:needs-template-fix label
+            const currentLabels = new Set((issue.labels || []).map((label) => label.name));
+            if (!currentLabels.has('status:needs-template-fix')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['status:needs-template-fix'],
+              });
+            }
+
+            core.warning(`Issue #${issue.number} was closed but does not meet requirements (${reasons.join('; ')}). Added guidance comment and status:needs-template-fix label.`);
 
   validate-push-guardrail:
     if: github.event_name == 'push'

--- a/.github/workflows/validate-issue-dod-before-close.yml
+++ b/.github/workflows/validate-issue-dod-before-close.yml
@@ -65,14 +65,7 @@ jobs:
               return;
             }
 
-            // Issue has unchecked DoD items; reopen and notify
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              state: 'open',
-            });
-
+            // Issue has unchecked DoD items; post guidance comment and label (don't reopen)
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -86,7 +79,7 @@ jobs:
 
             const message = [
               marker,
-              '🔄 This issue was automatically re-opened because the Definition of Done (DoD) is not complete.',
+              '⚠️ This issue was closed but the Definition of Done (DoD) is not complete.',
               '',
               '**Unchecked DoD items found.** Please complete all checklist items before closing this issue.',
               '',

--- a/.remember/now.md
+++ b/.remember/now.md
@@ -2,3 +2,11 @@
 ## 23:50 | refactor/prd-factory-planner-agent-skills
 
 Consolidated prd-agent + prd-factory-planner-agent (917 files, 144k LOC) into feat/prd-combined-agent branch, PR #1196 with multi-provider config, updated issues #1094/#1095/#1079, core CI passing.
+
+## 08:23 | ci/template-enforcement-fix
+
+Fixed linting in PR #1201 (ci/template-enforcement-fix) and template issues in #1200/#1221; validations pass but CI cache persists; attempted #1200 merge.
+
+## 08:25 | claude/issue-type-templates-e90252
+
+Applied issue templates to 22 issues (#1220-#1241) w/ DoR/DoD; documented bulk template process in docs/ISSUE_TRIAGE.md.


### PR DESCRIPTION
## Linked issues

Closes #1171
Relates to #1206, #1208

## Changelog

### Changed

- Modified `template-enforcement` workflow to provide guidance comments instead of silently reopening issues

## Summary

Modify template-enforcement workflow to provide better user experience when issues are closed with incomplete requirements.

## Test Plan

- [ ] Incomplete DoR/DoD closes → posts guidance comment + adds label (doesn't reopen)
- [ ] Complete DoR/DoD closes → allow close normally
- [ ] With `meta:force-close` label → allow close despite incomplete

### Checklist (Global DoD / PR)

- [x] Code follows project standards
- [x] Changes are documented/self-explanatory
- [x] Related issues are linked (#1206, #1208)
- [x] Changelog entry provided
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related Issue
Closes #1219