### PR TITLE
fix(ci): remove non-existent comp:help-tabs from label governance

### DIFF
--- a/.github/label-governance-policy.yml
+++ b/.github/label-governance-policy.yml
@@ -58,6 +58,5 @@ destructive_cleanup:
     - lang:md
     - lang:json
     - lang:yaml
-    - comp:help-tabs
     - meta:duplicate
     - meta:dependabot-security


### PR DESCRIPTION
## Linked issues

Closes #1168

## Changelog

### Removed

- Removed stale reference to non-existent `comp:help-tabs` label from label governance policy

## Summary

Remove stale label reference from governance policy.

## Test Plan

- [ ] Validation script passes without warnings

### Checklist (Global DoD / PR)

- [x] Code follows project standards
- [x] Changes are documented/self-explanatory
- [x] Related issues are linked
- [x] Changelog entry provided
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related Issue
Closes #1217