### PR TITLE
docs(governance): Integrate 9 agent standards into governance docs

### DIFF
--- a/.github/custom-instructions.md
+++ b/.github/custom-instructions.md
@@ -24,6 +24,22 @@ language: en
 
 These instructions apply to work performed inside the LightSpeed `.github` control-plane repository.
 
+## Documentation Standards for AI Infrastructure
+
+All agents, skills, instructions, workflows, plugins, and related AI components must comply with the 9 comprehensive standards documented in `docs/`. When creating or modifying AI infrastructure:
+
+- **Creating an agent?** → Reference [docs/AGENT_STANDARDS.md](../docs/AGENT_STANDARDS.md)
+- **Building a skill?** → Reference [docs/SKILLS_STANDARDS.md](../docs/SKILLS_STANDARDS.md)
+- **Writing instructions?** → Reference [docs/INSTRUCTIONS_STANDARDS.md](../docs/INSTRUCTIONS_STANDARDS.md)
+- **Designing a workflow?** → Reference [docs/WORKFLOWS_STANDARDS.md](../docs/WORKFLOWS_STANDARDS.md)
+- **Creating a cookbook?** → Reference [docs/COOKBOOKS_STANDARDS.md](../docs/COOKBOOKS_STANDARDS.md)
+- **Building prompts?** → Reference [docs/PROMPTS_STANDARDS.md](../docs/PROMPTS_STANDARDS.md)
+- **Developing a plugin?** → Reference [docs/PLUGINS_STANDARDS.md](../docs/PLUGINS_STANDARDS.md)
+- **Creating hooks?** → Reference [docs/HOOKS_STANDARDS.md](../docs/HOOKS_STANDARDS.md)
+- **Maintaining AI references?** → Reference [docs/AI_REFERENCES_STANDARDS.md](../docs/AI_REFERENCES_STANDARDS.md)
+
+See [AGENTS.md](../AGENTS.md#documentation-standards) for the complete quick reference guide and standards overview.
+
 ## Branch Protocol
 
 1. Before the first edit, confirm the current branch is in scope for the requested task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,7 @@ gh issue create --title "Bug title" --body "$BODY"
 
 | Area                      | File Reference                                                                                                                 | Notes / Usage                                                 |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| **Documentation Standards** | [docs/AGENT_STANDARDS.md](docs/AGENT_STANDARDS.md) + 8 more | 9 comprehensive standards for agents, skills, workflows, plugins, and AI infrastructure (SEE BELOW) |
 | **Coding Standards**      | [instructions/coding-standards.instructions.md](instructions/coding-standards.instructions.md)                 | Unified standards for all code                                |
 | **File Organisation**     | [instructions/file-organisation.instructions.md](instructions/file-organisation.instructions.md) | Where to create reports, tasks, and project files (CRITICAL)  |
 | **Quality Assurance**     | [instructions/quality-assurance.instructions.md](instructions/quality-assurance.instructions.md)               | Testing pyramid, Jest, coverage, CI/CD (3 files consolidated) |
@@ -288,6 +289,58 @@ gh issue create --title "Bug title" --body "$BODY"
 - **quality-assurance.instructions.md** - Testing, Jest, coverage, CI/CD (consolidated 3 files)
 - **automation.instructions.md** - Agents, labeling, release, metrics (consolidated 8 files)
 - **community-standards.instructions.md** - Files, naming, README, saved replies (consolidated 4 files)
+
+---
+
+## Documentation Standards
+
+All agents, skills, instructions, and related AI infrastructure must follow the 9 comprehensive standards documented below. These standards ensure consistency, maintainability, and professional quality across all AI-driven components.
+
+### Quick Reference Guide
+
+| Standard | Primary Use | Key Sections | Reference |
+| --- | --- | --- | --- |
+| **Agent Standards** | Single-file & folder-based agent design | Architecture, structure, configuration, patterns | [docs/AGENT_STANDARDS.md](docs/AGENT_STANDARDS.md) |
+| **Skills Standards** | Shared and dedicated skill creation | Skill lifecycle, structure, templates, quality gates | [docs/SKILLS_STANDARDS.md](docs/SKILLS_STANDARDS.md) |
+| **Instructions Standards** | Portable instruction files for agents | File structure, frontmatter, role declarations, validation | [docs/INSTRUCTIONS_STANDARDS.md](docs/INSTRUCTIONS_STANDARDS.md) |
+| **Workflows Standards** | Reusable agentic workflow patterns | Execution patterns, composition, error handling, examples | [docs/WORKFLOWS_STANDARDS.md](docs/WORKFLOWS_STANDARDS.md) |
+| **Cookbooks Standards** | Implementation guides and recipes | Cookbook lifecycle, structure, audience targeting, testing | [docs/COOKBOOKS_STANDARDS.md](docs/COOKBOOKS_STANDARDS.md) |
+| **Prompts Standards** | Reusable prompt templates & patterns | Prompt lifecycle, taxonomy, composition rules, validation | [docs/PROMPTS_STANDARDS.md](docs/PROMPTS_STANDARDS.md) |
+| **Plugins Standards** | Claude Code plugin architecture | Plugin lifecycle, structure, manifest, validation | [docs/PLUGINS_STANDARDS.md](docs/PLUGINS_STANDARDS.md) |
+| **Hooks Standards** | Event-driven hooks for automation | Hook execution, structure, validation, patterns | [docs/HOOKS_STANDARDS.md](docs/HOOKS_STANDARDS.md) |
+| **AI References Standards** | Canonical AI model & runner references | Reference lifecycle, maintenance, scope, tools | [docs/AI_REFERENCES_STANDARDS.md](docs/AI_REFERENCES_STANDARDS.md) |
+
+### When to Use Each Standard
+
+- **Creating a new agent?** → Read [AGENT_STANDARDS.md](docs/AGENT_STANDARDS.md)
+- **Building a reusable skill?** → Read [SKILLS_STANDARDS.md](docs/SKILLS_STANDARDS.md)
+- **Writing instruction files?** → Read [INSTRUCTIONS_STANDARDS.md](docs/INSTRUCTIONS_STANDARDS.md)
+- **Designing an agentic workflow?** → Read [WORKFLOWS_STANDARDS.md](docs/WORKFLOWS_STANDARDS.md)
+- **Creating a how-to guide?** → Read [COOKBOOKS_STANDARDS.md](docs/COOKBOOKS_STANDARDS.md)
+- **Building prompt templates?** → Read [PROMPTS_STANDARDS.md](docs/PROMPTS_STANDARDS.md)
+- **Developing a plugin?** → Read [PLUGINS_STANDARDS.md](docs/PLUGINS_STANDARDS.md)
+- **Creating event hooks?** → Read [HOOKS_STANDARDS.md](docs/HOOKS_STANDARDS.md)
+- **Maintaining AI references?** → Read [AI_REFERENCES_STANDARDS.md](docs/AI_REFERENCES_STANDARDS.md)
+
+### Standards Highlights
+
+Each standard document includes:
+
+- **Overview** — Purpose, scope, and use cases
+- **Lifecycle** — Phases from creation through maintenance
+- **Structure** — File organisation and mandatory sections
+- **Quality Gates** — Validation rules and compliance checklist
+- **Examples** — Real-world implementations and templates
+- **References** — Related standards and cross-links
+
+### Compliance & Validation
+
+All standards include:
+
+- **Frontmatter schema** — Validated against `.schemas/frontmatter.schema.json`
+- **Linting rules** — Markdown and content validation via `npm run lint:md`
+- **Type checking** — Schema compliance via `npm run validate:frontmatter`
+- **CI enforcement** — Automated validation in `.github/workflows/`
 
 ---
 
@@ -391,6 +444,7 @@ Start here for all key standards:
 
 | Resource Name             | Reference                                                        | Purpose / Notes                                                    |
 | ------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **Documentation Standards** | [docs/AGENT_STANDARDS.md](docs/AGENT_STANDARDS.md) (+ 8 more) | 9 comprehensive standards; see "Documentation Standards" section above |
 | **Instructions Guide**    | [instructions/instructions.instructions.md](instructions/instructions.instructions.md) | Guide for authoring and maintaining instruction files              |
 | **Custom Instructions**   | [.github/custom-instructions.md](.github/custom-instructions.md) | Repo-local Copilot instructions and `.github` boundary rules       |
 | **Claude Instructions**   | [CLAUDE.md](CLAUDE.md)                                           | Claude-specific project instructions; companion to this file       |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,8 @@ npm run validate:frontmatter
 
 **Schema folder note:** JSON schemas are stored in `.schemas/` (hidden folder at root) following the awesome-copilot pattern. This includes validation schemas for frontmatter, agents, plugins, skills, and other structured content. See [issue #1292](https://github.com/lightspeedwp/.github/issues/1292) for consolidation details.
 
+**Documentation Standards note (Phase 3A):** Comprehensive standards for creating agents, skills, instructions, workflows, plugins, and other AI infrastructure are maintained in `docs/`. These 9 standards documents are the authoritative reference for all AI-driven work. See [AGENTS.md#documentation-standards](./AGENTS.md#documentation-standards) for the complete quick reference guide.
+
 ## What Not to Do
 
 - Do not add WordPress plugin or theme project-specific code to `.github/`.

--- a/docs/AGENT_CREATION.md
+++ b/docs/AGENT_CREATION.md
@@ -26,6 +26,8 @@ tags:
 [![Validation](https://img.shields.io/badge/validation-automated-informational)](../schema/)
 
 > **Complete guide** for authoring agent specification files that follow LightSpeed organizational standards, including frontmatter requirements, documentation structure, implementation patterns, and validation processes.
+>
+> **NOTE (Phase 3A):** This guide is now supplemented by the comprehensive [AGENT_STANDARDS.md](./AGENT_STANDARDS.md) document, which provides end-to-end standards for agent design and architecture. For detailed agent structure, patterns, and quality gates, see [AGENT_STANDARDS.md](./AGENT_STANDARDS.md).
 
 ---
 


### PR DESCRIPTION
## Linked issues

Closes #1356
Relates to #1261

## What changed

- AGENTS.md: Add comprehensive "Documentation Standards" section with quick-reference table linking all 9 standards
- AGENTS.md: Update "Contribution Guidelines & Indexes" table to reference standards as primary reference
- AGENTS.md: Update "Cross-References & Discoverability" section with standards pointer
- .github/custom-instructions.md: Add "Documentation Standards for AI Infrastructure" section with quick links
- docs/AGENT_CREATION.md: Add informative note explaining relationship to AGENT_STANDARDS.md
- CLAUDE.md: Add standards note in Repository Boundaries section

## Audience & placement

- Audience: Contributors creating agents, skills, workflows, plugins, and related AI infrastructure
- Location: AGENTS.md (main governance file), governance-related docs

## Changelog

### Added

- Documentation Standards quick-reference guide in AGENTS.md with 9 standards integration (Phase 3A governance integration)
- Standards navigation pointers in .github/custom-instructions.md for quick lookup by task type
- Standards cross-reference in CLAUDE.md Repository Boundaries section
- Informative note in docs/AGENT_CREATION.md linking to AGENT_STANDARDS.md

### Changed

- AGENTS.md: Updated "Contribution Guidelines & Indexes" table to include Documentation Standards as primary reference
- AGENTS.md: Updated "Cross-References & Discoverability" section with standards pointer

---

### Checklist (Global DoD / PR)

- [x] All AC met and demonstrated
- [x] Tests added/updated (linting and link validation)
- [x] Docs/readme/changelog updated (this is a docs-focused PR)
- [x] Code/design reviews approved
- [x] CI green upon merge

---

🧱 Built by Claude Code for Phase 3A: Governance Integration