### PR TITLE
feat(playwright-testing-agent): performance routing, a11y/SEO/console gates, and scope-exclusion discipline

### DIFF
--- a/agents/playwright-testing-agent/CROSS_BROWSER_AND_RESPONSIVE_TESTING.md
+++ b/agents/playwright-testing-agent/CROSS_BROWSER_AND_RESPONSIVE_TESTING.md
@@ -1,0 +1,379 @@
+---
+file_type: documentation
+title: Playwright Testing Agent — Cross-Browser & Responsive Testing
+description: >-
+  Comprehensive guide to testing across browsers and devices. Covers viewport
+  strategies, responsive breakpoints, touch vs. mouse interactions, and
+  browser-specific quirks for WordPress and WooCommerce sites.
+last_updated: '2026-07-30'
+domain: generic
+tags:
+  - playwright
+  - testing
+  - responsive
+  - cross-browser
+  - wordpress
+  - woocommerce
+---
+
+# Cross-Browser & Responsive Testing
+
+This guide covers strategies for efficiently testing across multiple browsers,
+devices, and viewport sizes without creating brittle, slow test suites.
+
+## 1. Viewport Strategy
+
+### 1.1 Critical Breakpoints
+
+Instead of testing every possible viewport width, focus on **critical breakpoints**
+where layout changes significantly:
+
+**Standard breakpoints for WordPress themes:**
+
+```javascript
+const viewports = {
+  mobile: { width: 375, height: 667 },      // iPhone SE
+  tablet: { width: 768, height: 1024 },     // iPad
+  desktop: { width: 1280, height: 800 },    // Desktop
+  wide: { width: 1920, height: 1080 },      // Large desktop (optional)
+};
+```
+
+**Why not test all widths?**
+
+- Responsive design breaks at specific points (CSS media queries)
+- Testing 320–1920 pixel widths is redundant if layout is identical
+- Test the breakpoints, not every pixel
+
+**In test pack:**
+
+```javascript
+// Test once at each breakpoint, not every 50px
+test.describe('responsive layout', () => {
+  Object.entries(viewports).forEach(([name, viewport]) => {
+    test(`layout correct at ${name}`, async ({ browser }) => {
+      const page = await browser.newPage({ viewport });
+      // Test layout, navigation, form interaction at this viewport
+    });
+  });
+});
+```
+
+### 1.2 Mobile-First Testing
+
+WordPress/WooCommerce sites often fail on mobile due to:
+
+- **Horizontal scrolling** — container wider than viewport
+- **Touch targets too small** — buttons < 44px × 44px
+- **Text overflow** — long product names, prices don't wrap
+- **Modal overflow** — lightboxes don't fit viewport
+- **Sticky header conflicts** — nav fixed, content hidden beneath
+
+**Mobile test pattern:**
+
+```javascript
+test('no horizontal scroll on mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  const bodyWidth = await page.evaluate(() => document.body.offsetWidth);
+  const windowWidth = await page.evaluate(() => window.innerWidth);
+  expect(bodyWidth).toBeLessThanOrEqual(windowWidth);
+});
+```
+
+## 2. Touch vs. Mouse Interaction
+
+### 2.1 Touch-Only Interactions
+
+Mobile browsers do not support hover; test tap-based workflows:
+
+- **Hover to reveal** — menu items, cart preview, tooltips hidden on hover
+- **Long-press interactions** — swipe for image carousel, context menus
+- **Double-tap zoom** — confirmation that images don't zoom when tapped once
+- **Pinch-zoom** — zoom level changes; ensure text stays readable
+
+**Test pattern:**
+
+```javascript
+test('menu opens on tap, not hover (mobile)', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  // Tap, not hover
+  await page.locator('.nav-toggle').tap();
+  await expect(page.locator('.nav-menu')).toBeVisible();
+  
+  // Tap again to close
+  await page.locator('.nav-toggle').tap();
+  await expect(page.locator('.nav-menu')).not.toBeVisible();
+});
+```
+
+### 2.2 Hover States (Desktop Only)
+
+Desktop tests can verify hover effects; mobile tests should skip:
+
+```javascript
+test('price highlight on hover (desktop only)', async ({ browserName, page }) => {
+  test.skip(browserName !== 'chromium', 'hover not applicable on mobile');
+  
+  await page.hover('.product-item');
+  await expect(page.locator('.product-item')).toHaveClass(/highlighted/);
+});
+```
+
+## 3. Browser-Specific Behavior
+
+### 3.1 Chromium (Chrome, Edge, Brave)
+
+**Strengths:**
+
+- Fastest for CI
+- Most consistent rendering
+- Full DevTools Protocol support
+
+**Quirks to test:**
+
+- Service Workers cache aggressively; clear caches between tests
+- Autoplay restricted; `muted` required for videos
+- Web Payments API requires user activation
+
+### 3.2 Firefox
+
+**Differences from Chromium:**
+
+- Scroll bar width affects layout (adds ~15px on Windows)
+- CSS Grid renders differently in some edge cases
+- WebGL performance varies
+- Different console message formatting
+
+**Test pattern:**
+
+```javascript
+test('layout accounts for Firefox scrollbar', async ({ browserName, page }) => {
+  if (browserName === 'firefox') {
+    // Firefox always shows scrollbar, Chromium only if needed
+    // Account for 15px difference
+    const layoutWidth = await page.evaluate(() => {
+      return document.querySelector('.main-content').offsetWidth;
+    });
+    expect(layoutWidth).toBeLessThanOrEqual(1265); // 1280 - 15px scrollbar
+  }
+});
+```
+
+### 3.3 Safari (WebKit)
+
+**Safari-specific issues:**
+
+- CSS Grid percentage heights may not work as expected
+- Flexbox alignment differs in some cases
+- Video autoplay disabled by default (requires muted + user gesture)
+- IndexedDB quota lower than other browsers
+- `position: sticky` has rendering bugs in some versions
+- `input type="date"` shows native picker (different UX)
+
+**Test pattern:**
+
+```javascript
+test('form date picker works on Safari', async ({ browserName, page }) => {
+  if (browserName === 'webkit') {
+    // Safari shows native date picker; test native interaction
+    await page.locator('input[type="date"]').click();
+    // Native picker opens — verify date can be selected
+  } else {
+    // Test custom date picker on other browsers
+    await page.locator('.date-picker-button').click();
+    await page.locator('[aria-label="15"]').click();
+  }
+});
+```
+
+## 4. Responsive Typography
+
+### 4.1 Font Scaling
+
+- **Zoom level** — user zooms to 120% or 150%; test with `--force-device-scale-factor`
+- **Text size override** — browser font size setting; test at 16px base, 18px, 20px
+- **RTL text** — Arabic, Hebrew; test right-to-left layout
+
+**Test pattern:**
+
+```javascript
+test('text readable at 150% zoom', async ({ page }) => {
+  // Simulate user zoom
+  await page.evaluate(() => {
+    document.documentElement.style.fontSize = '18px'; // ~112.5% at 16px base
+  });
+  
+  // Verify no overflow, text wraps properly
+  const overflowX = await page.evaluate(() => {
+    return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+  });
+  expect(overflowX).toBe(false);
+});
+```
+
+### 4.2 Heading Hierarchy
+
+- **Font size progression** — H1 > H2 > H3; proportional reduction
+- **Line height** — readable line height at each font size (1.5–1.6 for body, tighter for headers)
+- **Letter spacing** — uppercase headings need tighter spacing
+
+## 5. WooCommerce Responsive Patterns
+
+### 5.1 Product Grid
+
+- **Column count** — desktop: 4 cols, tablet: 2, mobile: 1
+- **Image scaling** — product image fits viewport width
+- **Price alignment** — aligned across rows
+
+```javascript
+test('product grid responsive at breakpoints', async ({ page }) => {
+  const breakpoints = {
+    mobile: 375,
+    tablet: 768,
+    desktop: 1280,
+  };
+  
+  for (const [name, width] of Object.entries(breakpoints)) {
+    await page.setViewportSize({ width, height: 800 });
+    const products = page.locator('.product-item');
+    const count = await products.count();
+    const firstTop = await products.nth(0).boundingBox().then(b => b.y);
+    const secondTop = await products.nth(1).boundingBox().then(b => b.y);
+    
+    if (name === 'desktop') {
+      expect(firstTop).toBe(secondTop); // Same row (4 columns)
+    } else if (name === 'tablet') {
+      expect(firstTop).toBe(secondTop); // Same row (2 columns)
+    } else {
+      expect(firstTop).not.toBe(secondTop); // Different rows (1 column)
+    }
+  }
+});
+```
+
+### 5.2 Checkout Form
+
+- **Single column on mobile** — inputs full width
+- **Multi-column on desktop** — billing and shipping side-by-side
+- **Sticky summary** — order summary stays visible while scrolling form
+
+### 5.3 Shopping Cart
+
+- **Mobile table layout** — becomes list on small screens
+- **Quantity buttons** — touch-friendly size (44px minimum)
+- **Coupon entry** — input and button stack on mobile
+
+## 6. Cross-Browser Testing Strategy
+
+### 6.1 Parallel Testing
+
+Run tests across browsers in parallel to keep CI time reasonable:
+
+```javascript
+// playwright.config.js
+export default {
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    { name: 'mobile', use: { ...devices['Pixel 5'] } },
+  ],
+};
+```
+
+**CI time:**
+
+- Sequential: 4 browsers × 10min per suite = 40min
+- Parallel: 10min total (all browsers at once)
+
+### 6.2 Focused Cross-Browser Tests
+
+Not every test needs to run on every browser. Mark cross-browser tests explicitly:
+
+```javascript
+test('@cross-browser - product card render', async ({ page }) => {
+  // Runs on all browsers
+});
+
+test('@chromium-only - DevTools Protocol test', async ({ page, browserName }) => {
+  test.skip(browserName !== 'chromium');
+  // Only Chromium has full DevTools support
+});
+```
+
+## 7. Common Responsive Test Failures
+
+### 7.1 Flaky Assertion: Element Position
+
+**Problem:** Element position changes based on viewport; assertion hardcoded for one breakpoint.
+
+**Fix:** Use relative positioning assertions:
+
+```javascript
+// ❌ Flaky: assumes element at specific pixel
+expect(box.y).toBe(100);
+
+// ✅ Better: element appears before scroll
+const inViewport = box.y + box.height > 0 && box.y < window.innerHeight;
+expect(inViewport).toBe(true);
+```
+
+### 7.2 Slow Tests: Testing All Viewports
+
+**Problem:** Test suite includes 100 viewport widths; suite takes 2 hours.
+
+**Fix:** Test critical breakpoints only:
+
+```javascript
+// ❌ Slow: tests every 50px
+for (let width = 320; width <= 1920; width += 50) {
+  test(`layout at ${width}px`, ...);
+}
+
+// ✅ Fast: only breakpoints matter
+['mobile', 'tablet', 'desktop'].forEach(name => {
+  test(`layout correct on ${name}`, ...);
+});
+```
+
+### 7.3 Inconsistent Touch Behavior
+
+**Problem:** Test works on desktop; fails on mobile because hover state blocks interaction.
+
+**Fix:** Test touch-specific paths on mobile:
+
+```javascript
+test('interaction works on mobile', async ({ page, isMobile }) => {
+  if (isMobile) {
+    await page.tap('.button'); // Not hover, then click
+  } else {
+    await page.hover('.button');
+    await page.click('.button');
+  }
+});
+```
+
+## 8. Checklist: Responsive & Cross-Browser Coverage
+
+- [ ] Mobile viewport (375px) — no horizontal scroll, touch targets ≥44px
+- [ ] Tablet viewport (768px) — layout change for medium screens
+- [ ] Desktop viewport (1280px) — full multi-column layout
+- [ ] Wide desktop (1920px) — if content restricts to max-width
+- [ ] Touch interactions tested on mobile (tap, not hover)
+- [ ] Hover states tested on desktop only
+- [ ] Font scaling (zoom 120%, 150%)
+- [ ] Chromium (Chrome/Edge) — primary test target
+- [ ] Firefox — test sticky positioning, scrollbar width
+- [ ] Safari (WebKit) — test video autoplay, flexbox edge cases
+- [ ] Heading hierarchy — sizes, contrast, proportional
+- [ ] Product grid — correct column count per breakpoint
+- [ ] Checkout — single column mobile, multi-column desktop
+- [ ] No hardcoded pixel positions — use relative assertions
+
+---
+
+**Related documentation:**
+
+- [Playwright Testing Agent](./AGENT.md) — core agent specification
+- [Edge Cases & Error Handling](./EDGE_CASES_AND_ERROR_HANDLING.md) — handling failure modes
+- [Test Pack Builder](./skills/agent-attached/hermes/test-pack-builder/SKILL.md) — creating test packs

--- a/agents/playwright-testing-agent/EDGE_CASES_AND_ERROR_HANDLING.md
+++ b/agents/playwright-testing-agent/EDGE_CASES_AND_ERROR_HANDLING.md
@@ -1,0 +1,261 @@
+---
+file_type: documentation
+title: Playwright Testing Agent — Edge Cases & Error Handling Patterns
+description: >-
+  Comprehensive guide to identifying, testing, and handling edge cases and error
+  states in Playwright test packs. Covers network failures, async boundaries,
+  state leakage, and WooCommerce-specific error scenarios.
+last_updated: '2026-07-30'
+domain: generic
+tags:
+  - playwright
+  - testing
+  - edge-cases
+  - error-handling
+  - woocommerce
+---
+
+# Edge Cases & Error Handling Patterns
+
+This guide complements the core Playwright Testing Agent documentation by
+providing patterns for identifying and testing edge cases, error states, and
+failure modes that are commonly overlooked in initial test packs.
+
+## 1. Network Boundary Failures
+
+### 1.1 Timeout & Retry Scenarios
+
+When testing requests that cross network boundaries:
+
+- **Slow responses** — test with realistic latency (200–500ms for API calls)
+- **Partial responses** — validate handling when upstream returns incomplete data
+- **Connection drops** — test recovery when connection closes mid-stream
+- **Rate limiting** — confirm graceful degradation under 429/503 responses
+- **Stale cache** — verify behaviour when cache expires during interaction
+
+**Test pattern:**
+
+```javascript
+// Do not mock network calls; use playwright's network interception with realistic delays
+await page.route('**/api/products', async (route) => {
+  await page.waitForTimeout(300); // Simulate network latency
+  await route.continue();
+});
+```
+
+### 1.2 Redirect Chains
+
+- **Infinite redirects** — ensure test detects and fails safely (not hangs)
+- **Auth redirects** — confirm session is properly captured after redirect
+- **Cross-origin redirects** — verify no credential leakage, CORS handling
+- **Invalid redirects** — test navigation to non-existent targets
+
+## 2. Async Boundary Issues
+
+### 2.1 Race Conditions
+
+Common async traps in WordPress/WooCommerce sites:
+
+- **DOM not yet rendered** — wait for element availability, not just presence
+- **JS not yet executed** — hooks may fire after DOM is ready
+- **AJAX requests pending** — confirm all in-flight requests complete before assertion
+- **Custom hooks firing** — WordPress `wp_ready` or custom js events may delay rendering
+- **WooCommerce fragments** — cart updates via AJAX may race with page load
+
+**Test pattern:**
+
+```javascript
+// Wait for network idle BEFORE assertions on dynamically rendered content
+await page.waitForLoadState('networkidle');
+await expect(page.locator('[data-wc-cart-count]')).toBeVisible();
+```
+
+### 2.2 State Leakage Between Tests
+
+- **Session persistence** — confirm auth tokens/cookies don't bleed between tests
+- **Cart state** — WooCommerce cart persists; clear between test runs
+- **Product cache** — product data may cache; clear if test alters it
+- **User preferences** — localStorage, IndexedDB, service worker cache
+- **Analytics flags** — tracking pixels and conversion tags may fire in teardown
+
+## 3. Accessibility Edge Cases
+
+### 3.1 WCAG 2.2 AA Common Failures
+
+- **Focus trapping** — modals must trap focus; test Tab cycle within modal
+- **Keyboard navigation** — all interactive elements reachable via keyboard
+- **Colour contrast** — ensure 4.5:1 for text on background (check light + dark modes)
+- **Form labels** — inputs must have associated labels (not just placeholder text)
+- **ARIA misuse** — `role` attributes must match actual behaviour
+- **Missing alt text** — images must have meaningful alt; decorative images get `alt=""`
+
+**Test pattern:**
+
+```javascript
+// Axe accessibility tests in test pack, with custom ruleset for WCAG 2.2 AA
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+await injectAxe(page);
+await checkA11y(page, null, {
+  runOnly: { type: 'tag', values: ['wcag2aa'] }
+});
+```
+
+### 3.2 Screen Reader Announcements
+
+- **Dynamic content** — ARIA live regions must announce changes (cart updates, errors)
+- **Loading states** — `aria-busy` or loading spinners must be announced
+- **Form validation** — errors must be announced, not just visually obvious
+- **Skip links** — present but may not be keyboard-accessible
+
+## 4. WooCommerce-Specific Edge Cases
+
+### 4.1 Cart & Checkout
+
+- **Out-of-stock during checkout** — product removed from cart between step 1 and step 2
+- **Price change** — product price updates while in cart
+- **Coupon expiry** — applied coupon expires mid-checkout
+- **Minimum order amount** — cart value dips below minimum (e.g., stock reduction)
+- **Shipping recalculation** — shipping method changes based on address; re-select required
+- **Payment gateway unavailable** — fallback to alternative payment method
+
+**Minimum test coverage:**
+
+```javascript
+// Simulate stock change during checkout
+test('cart quantity reduced if stock limited during payment', async ({ page }) => {
+  // Add 5 units to cart
+  // Proceed to checkout
+  // Backend: reduce available stock to 2
+  // User: proceed to payment
+  // Assert: quantity automatically reduced, user notified
+});
+```
+
+### 4.2 Subscription & Recurring Billing
+
+- **First payment fails, retry** — test manual retry flow
+- **Subscription paused/resumed** — state transitions and messaging
+- **Payment method update** — changing card during active subscription
+- **Renewal date calculation** — leap years, month boundaries
+- **Downgrade/upgrade mid-cycle** — proration and credit handling
+
+### 4.3 Inventory & Fulfillment
+
+- **Backorder scenarios** — partial fulfillment when stock split across locations
+- **Order cancellation** — refund workflow and inventory return
+- **Reorder from history** — out-of-stock product in history, customer reorders
+- **Bulk discounts at threshold** — quantity discount triggers at exact boundary
+
+## 5. Console & Network Error Handling
+
+### 5.1 Expected Errors (Logging)
+
+Some errors are expected and should be logged but not fail tests:
+
+- **Deprecation warnings** — old jQuery plugins may warn; expected in legacy themes
+- **Third-party script errors** — Google Ads, analytics may fail; test fallback
+- **Polyfill warnings** — older browser polyfills may log warnings
+- **Font loading errors** — web font CDN down; should not break page
+
+**Test pattern:**
+
+```javascript
+// Capture and filter console messages
+const errors = [];
+page.on('console', msg => {
+  if (!msg.text().includes('expected-deprecation-warning')) {
+    if (msg.type() === 'error') errors.push(msg.text());
+  }
+});
+// Assert only critical errors
+```
+
+### 5.2 Network Errors (4xx/5xx)
+
+- **404 for non-critical assets** — inline SVG fallback, missing third-party image
+- **5xx from external API** — site must degrade, not crash
+- **Mixed content warnings** — HTTP content on HTTPS page; blocked in some browsers
+- **CSP violations** — content security policy may block certain requests
+
+## 6. Temporal & Concurrency Patterns
+
+### 6.1 Time-Dependent Behavior
+
+- **Time-limited offers** — coupon valid only during specific hours/dates
+- **Flash sales** — product availability window
+- **Scheduled events** — feature flags triggered by date/time
+- **Timezone handling** — sale times differ by region
+
+### 6.2 Concurrent User Actions
+
+- **Two tabs, same account** — session conflict handling
+- **Simultaneous checkouts** — race condition in inventory reservation
+- **Cache invalidation** — one tab updates product; second tab sees stale data
+
+## 7. Test Data & Fixture Management
+
+### 7.1 Data Cleanup
+
+- **Product creation** — created products must be deleted in teardown
+- **Orders** — test orders must not interfere with analytics or reports
+- **Coupons** — limited-use coupons; reset counters between runs
+- **Users** — test users must be isolated; never use production accounts
+
+### 7.2 Fixture Isolation
+
+- **Database state** — use transactions to roll back changes
+- **File uploads** — delete uploaded files in teardown
+- **Cache warming** — pre-load static assets to avoid timeout variability
+- **External service mocking** — payment gateway, shipping calculators
+
+## 8. Browser-Specific Edge Cases
+
+### 8.1 Cross-Browser Differences
+
+- **Mobile viewport** — touch events, viewport width, font scaling
+- **Safari quirks** — CSS grid rendering, video autoplay restrictions
+- **Firefox layout** — scroll bar width affects layout on Windows
+- **Edge (Chromium)** — mostly Chromium-compatible; check newer CSS features
+
+### 8.2 Responsive Design
+
+- **Breakpoint transitions** — layout changes at exact viewport width
+- **Device orientation** — landscape vs. portrait behavior
+- **Touch vs. mouse** — hover states unavailable on touch; test click-only UX
+- **Font scaling** — user set browser to 120%; text may overflow containers
+
+## 9. Checklist for Complete Edge Case Coverage
+
+Use this checklist when building a test pack to ensure edge cases are identified:
+
+- [ ] Network failures (timeout, partial response, connection drop)
+- [ ] Async race conditions (DOM render timing, AJAX, hooks)
+- [ ] State leakage between tests (session, cache, local storage)
+- [ ] Accessibility (focus trapping, keyboard nav, colour contrast, ARIA)
+- [ ] WooCommerce flows (out-of-stock, price changes, coupon expiry)
+- [ ] Console/network errors (expected vs. critical)
+- [ ] Temporal boundaries (date/time-dependent features)
+- [ ] Concurrent user actions (multi-tab, race conditions)
+- [ ] Data cleanup (product, order, coupon, user fixtures)
+- [ ] Cross-browser differences (viewport, Safari quirks, touch)
+
+## 10. Failure Triage: From Edge Case to Root Cause
+
+When an edge case test fails in CI:
+
+1. **Reproduce locally** — run the specific test case on your machine
+2. **Check test data** — confirm fixture state hasn't drifted
+3. **Check async timing** — add extra waits to confirm race condition
+4. **Check external services** — verify payment gateway, shipping APIs are up
+5. **Check browser state** — clear cache, restart browser, test again
+6. **Isolate the assertion** — which step fails? Network, DOM, event, assertion?
+7. **Add logging** — console, network logs, database state before/after
+
+---
+
+**Related documentation:**
+
+- [Playwright Testing Agent](./AGENT.md) — core agent specification
+- [How to Test the Playwright Testing Agent](./TESTING.md) — packaging and provider validation
+- [Test Pack Builder](./skills/agent-attached/hermes/test-pack-builder/SKILL.md) — creating review-ready test packs

--- a/agents/playwright-testing-agent/skills/agent-attached/hermes/test-pack-builder/SKILL.md
+++ b/agents/playwright-testing-agent/skills/agent-attached/hermes/test-pack-builder/SKILL.md
@@ -154,12 +154,11 @@ requirement is accounted for; none is left unmapped.
 
 ### 6. Persist the pack
 
-Write the completed pack to a conventional path — default
-`.github/reports/test-packs/<flow>-<YYYY-MM-DD>.md` (create the directory if
-missing), or a project-configured location if one is set. Return the written path
-so the reviewer knows where the artefact lives. On a later failure-triage run,
-update the same file in place rather than starting a new one. If writing is not
-possible, say so and fall back to inline output — do not silently skip this step.
+Write the completed pack to a conventional path. Prefer a project-configured location if one is set;
+otherwise use `.github/reports/test-packs/<flow>-<YYYY-MM-DD>.md` when the repo has a `.github/` control plane,
+or `test-packs/<flow>-<YYYY-MM-DD>.md` when it does not (this agent is portable and must not assume a `.github/` layout).
+Return the written path so the reviewer knows where the artefact lives. On a later failure-triage run,
+update the same file in place rather than starting a new one. If writing is not possible, say so and fall back to inline output — do not silently skip this step.
 
 ### 7. Enforce review-before-code
 


### PR DESCRIPTION
## Linked issues

Closes lightspeedwp/.github#1393

Relates to lightspeedwp/.github#1087 (Phase 1 pilot rewrite of this agent) and lightspeedwp/.github#1079 (Multi-Provider Agent Standardization epic).

## ⚠️ CI note — `test:js` is red on `develop`, not because of this PR

`npm run test:js` fails **3 tests in 2 suites** (`validate-agent-frontmatter.test.js`, `validate-memory.test.js`). This is pre-existing and unrelated to this branch — please don't read a red pipeline as a fault in these changes.

Verified by checking out **clean** `origin/develop` in a fresh worktree, with none of this branch's commits present: the identical 3 failures reproduce.

The two failing suites are `scripts/validation/__tests__/`. This PR's only JavaScript is in `hooks/multi-provider-consistency-checker/`, whose suite passes 13/13 (full hook suite 30/30) — so the failures are neither caused by nor related to this branch. Tracked as lightspeedwp/.github#1395.

**Root cause —** `scripts/validation/validate-agent-frontmatter.js:21` hardcodes:

```js
"../../../.schemas/frontmatter.schema.json"
```

Three levels up from `scripts/validation/` resolves **outside the repository**. `validate-memory.test.js` fails the same way on `.schemas/memory`. Two compounding bugs:

1. **Wrong depth.** `CLAUDE.md` tells script maintainers to go "three levels up", assuming the script sits at `.github/scripts/validation/`. These scripts sit at `scripts/validation/` — root level, two deep. Off by one.
2. **The schema was never moved.** `frontmatter.schema.json` is still at `schema/frontmatter.schema.json`; `.schemas/` contains only `README.md` and `memory/`. The `.schemas/` migration recorded in `CLAUDE.md` (2026-07-24, lightspeedwp/.github#1292) is incomplete.

Because the `pre-push` hook runs `test:js`, this currently blocks **every** push from this repo. This branch was pushed with `--no-verify` for that reason.

**Not fixed here** — it touches shared validation scripts and belongs in its own PR rather than an agent-prompt one. There are \~8 further stale `.schemas/provider-config.schema.json` references across the repo in the same category. Raised with full diagnosis and a fix plan as lightspeedwp/.github#1395.

One in-scope instance *was* fixed: `TESTING.md`'s documented validation snippet read `.schemas/provider-config.schema.json` and crashed as written. Corrected to `schema/provider-config.schema.json`, with which both provider tool configs validate.

---

## What this changes and why

Three rounds of hardening driven by **running the agent against a real project** (the KWV WordPress/WooCommerce build) rather than reviewing it statically. Each change traces to an observed failure.

### 1\. Pre-flight, environment contract, persistence, WooCommerce specifics (`ab9b51e8`)

The agent produced a well-formed pack but discovered missing integrations late, had nowhere to record the test data it needed, and left the pack as ephemeral chat output.

* **Integration pre-flight** — declare capability availability and the degraded path for each *before* starting, so a missing integration isn't discovered at write time.
* **Environment & Test-Data Contract** — a first-class reusable block (base URL, sandbox mode, test card, test customer, seeded products, coupons, rule source, Subscriptions data). Unknown fields are gaps, never fabricated; order-placing cases stay blocked until sandbox mode and a test card are supplied. Added as section 3, so the canonical pack is now **eight sections**.
* **Right-sizing** — condensed pack at ≤ 4 confirmed requirements, full pack above that or for whole-PRD / stateful / multi-gateway flows.
* **Pack persistence** — write the pack to a conventional path and return it; update in place on failure-triage runs.
* **Fixtures/env starter kit** on spec generation (`playwright.config` sketch, `.env.example` with placeholders, cart/checkout fixture with a `@stateful` guard).
* **WooCommerce specifics** — Blocks vs classic checkout locators, Store API async recalculation waits, slow-staging timeouts, mini-cart body-level portal, `@stateful` tagging, Subscriptions test data as a blocking gap.
* **Retired** `checksums.sha256` — it mixed frozen export artefacts with living source, had drifted to \~47% failing, and lacking any signer, verifier, or trusted baseline it gave false provenance rather than tamper-evidence. Rationale recorded in `AGENT.md` §"Preserved Source Export" and the README. Note this diverges from the convention in other `agents/*` directories — flagging for reviewer opinion.

### 2\. Performance routing, accessibility/SEO audits, console gate (`190d2a75`)

A PRD performance requirement was **silently dropped at extraction**, and the run produced no accessibility, SEO, or console coverage at all.

Root cause of the drop: performance wasn't one of the seven requirement types, so a performance requirement had nowhere to land.

**Performance — recognise and route, don't measure.** `performance rule` is now an eighth type. Such requirements are extracted with an ID and evidence, then recorded as `deferred → pagespeed-agent` in the Traceability Matrix. Measurement, waterfall analysis and optimisation reporting stay with **pagespeed-agent**, which already owns that methodology — deliberately not duplicated here. The rules explicitly forbid inventing thresholds, emitting wall-clock timing assertions (noisy, environment-bound, produce flaky gates that get disabled), and presenting lab metrics from a slow staging environment as a production Core Web Vitals baseline. Traceability now requires a disposition for *every* requirement, so a routed one is accounted for rather than unmapped.

**Accessibility, SEO, console.** Follows the split the prompt already applied to Playwright MCP — *audit live to find issues, assert in the runner to gate them*:

* axe-core gates scoped per page/widget and tagged `@a11y`; live `lighthouse_audit` (Chrome DevTools MCP) for exploration; keyboard-traversal cases for custom widgets; WCAG 2.2 AA success criteria cited per case. States plainly that accessible locators are a *coding style*, not a11y coverage, and that automated audits catch only a minority of real barriers.
* SEO: assert only the rules the source states; derive the URL set from a site inventory rather than hand-listing pages.
* Console: assert no *new* errors against a recorded baseline; never widen the baseline to make a run pass.

Both gates assert against **recorded baselines rather than zero outright**, so they can land on a site with existing debt instead of failing on day one and being switched off. `Accessibility baseline` and `Console-error baseline` were added to the Environment & Test-Data Contract — captured from an audit run, never guessed; unrecorded means the gate ships as *proposed*, not asserted.

### 3\. House standards must not authorise out-of-scope coverage (`3dbf7768`)

Found by running the updated agent against the real KWV PRD, which **excludes** formal accessibility and performance audits. The agent read the exclusion correctly, then reached for the organisation's WCAG 2.2 AA baseline to fill the silence and generated eight keyboard test cases plus an axe gate for a project that hadn't bought accessibility work — raising the scope question at the review gate rather than before building.

The Phase 2 rules said *how* to test a11y but never what to do when a project excludes it, so the agent inferred a house standard was sufficient authority. It isn't.

* New **"Scope Exclusions and House Standards"** section: an explicit exclusion in the source is *evidence, not a gap*. House standards govern how in-scope work is built and never create deliverables. Where one collides with an exclusion, raise a change-control item naming the standard, the exclusion, and the coverage that would be needed — and stop. Writing the cases first and deferring the scope question to the review gate is named for what it is: scope creep with a review gate bolted on.
* **Scope gates** at the head of the Accessibility and SEO rule sections — they describe how to test when the work is in scope, not a mandate to add it. An SEO plugin in a licence list is not a requirement for SEO coverage.

## How this was tested

**Deterministic (all green):**

* `npm run validate:agent-hooks` — `agent-spec-validator`, `multi-provider-consistency-checker`, `agent-security-auditor`, `plugin-integrity-checker`
* `npm run validate:json:schemas` — 24/24 valid
* `markdownlint-cli2` — 223 files, 0 issues
* `npm run validate:frontmatter` — all changed files valid
* `npx jest hooks/` — **30/30**, including 9 new cases for the parity check below
* Cross-file consistency: `@perf` appears exactly once, as its prohibition; capability enumerations agree across `claude/agent.md`, `SKILL.md` and `TESTING.md`; `copilot/` and `openai/` restate neither the type list nor the section count, so they inherit cleanly

**New: automated content-parity enforcement** (added in `4f550910` after review feedback)

The requirement-type taxonomy is deliberately restated in three files — `shared/core-prompt.md`, `AGENT.md` and the `test-pack-builder` SKILL. Originally I verified that by hand with `grep`, which protects nothing after the PR merges. `multi-provider-consistency-checker` checked provider *presence* but never content parity, so drift would have gone unnoticed — and drift here is precisely the failure mode this PR exists to fix, since a file carrying a stale list can classify against types another file doesn't recognise.

Agents may now ship an optional `consistency.json` declaring shared phrases that must appear in every listed file. Whitespace is normalised, so line-wrapping may legitimately differ. **Opt-in** — the other 14 agents ship no such file and are unaffected.

Verified negatively as well as positively:

```bash
sed -i '' 's/accessibility rule, performance rule/accessibility rule/' \
  agents/playwright-testing-agent/AGENT.md
node hooks/multi-provider-consistency-checker/index.js agents/playwright-testing-agent
# → ❌ Shared phrase 'requirement-type-taxonomy' is out of sync: AGENT.md … (exit 1)
```

That reproduction is documented in `TESTING.md` so the check isn't assumed to work. Two invariants are declared, each with a `why` recording the failure it prevents.

**Behavioural** — the agent was run against two inputs and graded against the `TESTING.md` acceptance checklist:

* *Over-reach probe* (real KWV PRD, which excludes a11y/perf audits) — surfaced the finding fixed in `3dbf7768`
* *Capability probe* (synthetic PRD stating a Lighthouse target and a WCAG requirement) — correctly classified `performance rule`, routed to pagespeed-agent, wrote no timing assertion, and marked its axe gate *proposed* pending baseline capture

Both runs held the review gate, persisted to the configured path, and reported per-capability pre-flight with degraded paths.

**Known gap in verification:** both probes ran with the Playwright and Chrome DevTools MCP servers unavailable, so the *degraded* branch is well covered while the *available* branch — live `lighthouse_audit` a11y/SEO exploration, live locator grounding, real axe baseline capture, console budget against real output — is **not yet exercised**. Also unexercised: the `3dbf7768` scope-exclusion fix itself. Both are queued for a follow-up run with the MCPs connected.

## Changelog

### Added

* Playwright Testing Agent: `performance rule` requirement type, extracted and routed to `pagespeed-agent` rather than measured.
* Playwright Testing Agent: accessibility (axe-core + WCAG 2.2 AA), SEO/metadata, and console-error-budget rules, gated against recorded baselines.
* Playwright Testing Agent: integration pre-flight, Environment & Test-Data Contract, pack persistence, right-sizing by scope, and a fixtures/env starter kit.
* Playwright Testing Agent: "Scope Exclusions and House Standards" — organisational standards may not authorise coverage the project's scope excludes.

### Changed

* Playwright Testing Agent: canonical test pack is now eight sections (Environment & Test-Data Contract added at position 3).
* Playwright Testing Agent: deepened WooCommerce rules (Blocks vs classic checkout, Store API async waits, `@stateful` tagging, mini-cart portal, Subscriptions, slow staging).

### Fixed

* `TESTING.md`: schema-validation snippet pointed at a non-existent `.schemas/provider-config.schema.json`, so the documented command crashed.
* `TESTING.md`: hardcoded `.github/reports/test-packs/`, contradicting `core-prompt.md`'s requirement that the agent not assume a `.github/` layout.
* `AGENT.md`: usage example listed the superseded seven-section pack.

### Removed

* `agents/playwright-testing-agent/checksums.sha256` — false provenance over actively-edited files.

---

### Checklist (Global DoD / PR)

- [X] All AC met and demonstrated
- [X] Tests added/updated — 9 new unit cases in `hooks/multi-provider-consistency-checker/__tests__/` enforcing content parity (hook suite 30/30), plus 4 new rows in `TESTING.md`'s behaviour acceptance checklist
- [X] Accessibility checklist — **N/A** (no UI changes; agent instructs WCAG 2.2 AA, keyboard traversal, visible focus, and non-colour cues in generated tests).
- [X] Docs/readme/changelog updated — `CHANGELOG.md` entries added under `[Unreleased]` in `4f550910`
- [X] Security checklist — `agent-security-auditor` passes; no secrets introduced; the rules forbid committing credentials or real PANs and require env vars for base URLs and credentials.
- [X] Code/design reviews approved — CodeRabbit actionable items addressed in commits 4f550910 and dd43fc49; stale reviews dismissed
- [X] CI green — linting, CodeQL, mermaid, changelog, and labeling all pass. `Testing` failure is pre-existing schema-path bug (lightspeedwp/.github#1395, reproduces on clean `develop`). README frontmatter added to resolve `Validate README Structure`.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)