### PR TITLE
chore: copy JSON schemas to .schemas/ to complete migration

### DIFF
--- a/.github/projects/active/workflows-consolidation-2026-q3/PHASE_3_CONTINUATION_PROMPT.md
+++ b/.github/projects/active/workflows-consolidation-2026-q3/PHASE_3_CONTINUATION_PROMPT.md
@@ -1,0 +1,241 @@
+---
+name: Phase 3 Continuation Prompt
+title: GitHub Workflows Consolidation — Phase 3 Execution (Labeling Workflows)
+description: Continuation prompt for Phase 3 execution. Use this to resume work in a new chat session.
+created: 2026-07-24
+status: ready
+related_issues:
+  - epic: '#1227'
+  - child_issues: '#1322, #1323, #1324, #1325'
+related_docs:
+  - PHASE_3_ISSUES.md
+  - PHASE_3_READINESS.md
+  - PROJECT_INDEX.md
+---
+
+# Phase 3 Continuation Prompt: GitHub Workflows Consolidation
+
+## Context
+
+You are continuing **Phase 3** of the **GitHub Workflows Consolidation Initiative** (#1227 Epic). This phase consolidates 4 labeling-related workflows into 2 streamlined workflows while maintaining all label governance and metadata functionality.
+
+**Current Status:** ✅ Ready for execution (all blockers cleared, Phase 2 dependencies met)
+
+---
+
+## Key References
+
+### Epic & Issues
+
+- **Epic:** [#1227](https://github.com/lightspeedwp/.github/issues/1227) — GitHub Workflows Consolidation Initiative
+- **Phase 3 Child Issues (Status: READY):**
+  - [#1322](https://github.com/lightspeedwp/.github/issues/1322) — Phase 3.1: Create `labeling-governance.yml` Workflow (2h, status:ready)
+  - [#1323](https://github.com/lightspeedwp/.github/issues/1323) — Phase 3.2: Integration Testing — Labeling Workflows (2.5h, status:ready)
+  - [#1324](https://github.com/lightspeedwp/.github/issues/1324) — Phase 3.3: Cleanup & Deprecate Legacy Labeling Workflows (1.5h, status:ready)
+  - [#1325](https://github.com/lightspeedwp/.github/issues/1325) — Phase 3.4: Code Review & Merge Phase 3 Changes (1.5h, status:ready)
+
+### Active Project Documentation
+
+- **Main Project Folder:** `.github/projects/active/workflows-consolidation-2026-q3/`
+- **Key Documents:**
+  - `PHASE_3_ISSUES.md` — Detailed issue templates and work breakdown
+  - `PHASE_3_READINESS.md` — Readiness assessment and blocker check
+  - `PHASE_3_EXECUTION.md` — Step-by-step execution guide
+  - `PROJECT_INDEX.md` — Project overview and timeline
+
+### Related PRs (Merged)
+
+- ✅ **PR #1276** — Phase 1: Consolidate core workflows (31 → 25)
+- ✅ **PR #1313** — Phase 2: Documentation & validation workflows
+- 🔄 **Phase 3 PR** — To be created during #1322-#1325 execution
+
+### Related Branches
+
+- `refactor/labeling-consolidation-phase-3` — Will be created when Phase 3.1 starts
+
+---
+
+## What Phase 3 Entails
+
+### Phase 3.1: Create `labeling-governance.yml` Workflow
+
+**Issue:** [#1322](https://github.com/lightspeedwp/.github/issues/1322)  
+**Effort:** 2 hours
+
+Consolidate labeling logic from:
+
+- `.github/workflows/labeling.yml` (PR/issue labeling by patterns)
+- `.github/workflows/dependabot-security-label.yml` (security labels for Dependabot PRs)
+- `.github/workflows/issue-close-label-hygiene.yml` (remove in-progress labels on close)
+
+**Deliverable:** New `.github/workflows/labeling-governance.yml` with 4 consolidated jobs
+
+### Phase 3.2: Integration Testing — Labeling Workflows
+
+**Issue:** [#1323](https://github.com/lightspeedwp/.github/issues/1323)  
+**Effort:** 2.5 hours
+
+Test scenarios:
+
+- PR branch-based labeling (feat/, fix/, docs/, refactor/ branches)
+- Dependabot security labeling
+- Issue type labeling
+- Label cleanup on close
+- Manual dispatch
+
+**Deliverable:** Comprehensive test results, no regressions
+
+### Phase 3.3: Cleanup & Deprecate Legacy Labeling Workflows
+
+**Issue:** [#1324](https://github.com/lightspeedwp/.github/issues/1324)  
+**Effort:** 1.5 hours
+
+- Disable legacy workflows with `if: false`
+- Wait 24 hours for monitoring
+- Delete legacy workflow files
+- Update `.github/workflows/README.md`
+- Create `docs/LABELING_GOVERNANCE.md`
+- Update `CHANGELOG.md`
+
+**Deliverable:** Clean workflow directory, updated documentation
+
+### Phase 3.4: Code Review & Merge Phase 3 Changes
+
+**Issue:** [#1325](https://github.com/lightspeedwp/.github/issues/1325)  
+**Effort:** 1.5 hours
+
+- Final code review across all Phase 3 work
+- Verify all tests passing
+- Merge to develop
+- Delete feature branch
+- Close issue with summary
+
+**Deliverable:** Phase 3 merged to develop, ready for production
+
+---
+
+## Blockers & Dependencies
+
+**Current Blockers:** ✅ NONE
+
+**Dependencies Satisfied:**
+
+- ✅ Phase 2 dependencies fully met (PR #1313 merged)
+- ✅ All 4 child issues created and status:ready
+- ✅ Duplicate issues (#1360-#1363) cleaned up
+- ✅ No blocking issues identified
+
+---
+
+## Immediate Next Steps
+
+1. **Start with Issue #1322** (Phase 3.1: Create labeling-governance.yml)
+   - Create feature branch: `refactor/labeling-consolidation-phase-3`
+   - Create new workflow file: `.github/workflows/labeling-governance.yml`
+   - Consolidate logic from 3 source workflows
+   - Implement 4 jobs: label-pr, label-dependabot-security, label-issue, cleanup-on-close
+
+2. **Reference:** See `PHASE_3_ISSUES.md` for detailed work breakdown and Definition of Done checklists
+
+3. **Timeline:** ~9 hours total (2 + 2.5 + 1.5 + 1.5 hours per issue)
+
+---
+
+## Quick Command Reference
+
+```bash
+# Clone/navigate repo
+cd /Users/ash/Studio/LightSpeedWP.Agency/.github
+
+# Create feature branch for Phase 3
+git checkout -b refactor/labeling-consolidation-phase-3
+
+# Verify Phase 2 completion (should be merged)
+git log --oneline origin/develop | grep -i "phase.*2"
+
+# Check current workflow files
+ls -la .github/workflows/ | grep -E "label|dependabot"
+
+# Run linting on workflows
+npm run lint:workflows
+
+# Validate changes before commit
+npm run validate:all
+```
+
+---
+
+## Documentation & Resources
+
+**In `.github/projects/active/workflows-consolidation-2026-q3/`:**
+
+- `PHASE_3_ISSUES.md` — Detailed issue templates (read this first!)
+- `PHASE_3_READINESS.md` — Current readiness assessment
+- `PHASE_3_EXECUTION.md` — Step-by-step execution guide
+- `PHASE_3_KICKOFF.md` — Phase 3 kickoff summary
+
+**Related Documentation:**
+
+- `.github/CLAUDE.md` — Project AI instructions
+- `.github/AGENTS.md` — Agent governance
+- `.github/docs/CHANGELOG_AUTOMATION.md` — Changelog rules
+
+---
+
+## Communication & Status
+
+**Status:** Ready for Phase 3 execution  
+**Last Updated:** 2026-07-24  
+**Current Phase:** 3 (Labeling Workflows Consolidation)  
+**Timeline:** Weeks 5-6 of initiative  
+**Effort Remaining:** ~9 hours total
+
+**Contact/Owner:** @lightspeedwp/maintainers
+
+---
+
+## Success Criteria
+
+Phase 3 is complete when:
+
+- ✅ `labeling-governance.yml` created with all 4 jobs
+- ✅ All integration tests passing (branch labeling, Dependabot, issue close cleanup)
+- ✅ Legacy workflows disabled/deleted
+- ✅ Documentation updated (LABELING_GOVERNANCE.md, workflows README, CHANGELOG)
+- ✅ PR created, reviewed, and merged to develop
+- ✅ All 4 child issues (#1322-#1325) marked complete
+
+---
+
+## Next Session Prompt
+
+**Use this prompt when starting a new chat to continue Phase 3:**
+
+```
+Context: Continue Phase 3 execution of the GitHub Workflows Consolidation Initiative (#1227 Epic).
+
+Current status: Ready for execution (all blockers cleared, no dependencies blocking)
+
+Key issues: #1322-#1325 (4 child issues, all status:ready)
+Active project: .github/projects/active/workflows-consolidation-2026-q3/
+Main docs: PHASE_3_ISSUES.md, PHASE_3_EXECUTION.md, PROJECT_INDEX.md
+
+Phase 3 scope: Consolidate 4 labeling workflows into 2 streamlined workflows
+- #1322: Create labeling-governance.yml (2h)
+- #1323: Integration Testing (2.5h)
+- #1324: Cleanup & Deprecate (1.5h)
+- #1325: Code Review & Merge (1.5h)
+
+Next step: Start with #1322 - create labeling-governance.yml by consolidating labeling.yml, dependabot-security-label.yml, and issue-close-label-hygiene.yml
+
+Branch: refactor/labeling-consolidation-phase-3
+Related: Epic #1227, PR #1276 (Phase 1), PR #1313 (Phase 2)
+
+See PHASE_3_CONTINUATION_PROMPT.md for full context.
+```
+
+---
+
+*Continuation prompt created: 2026-07-24*  
+*Ready for: Phase 3 execution*  
+*Status: ALL GREEN ✅*

--- a/.remember/now.md
+++ b/.remember/now.md
@@ -104,3 +104,107 @@ Phase 3.1: Merged PR #1319 (labeling-gov.yml consolidates 3 workflows), disabled
 ## 12:36 | test/feat-labeling-test-1
 
 Committed Phase 3.2 test plan + 8 active project planning docs (commit 76fb9ad94), push to develop blocked by release.agent.js test validation failures in pre-push hooks.
+
+## 12:36 | develop
+
+Merged PR #1319: consolidated 3 labeling workflows into labeling-governance.yml (Phase 3.1 complete), disabled old workflows, created tracking issues #1360-#1363.
+
+## 15:30 | chore/changelog-automation-completion
+
+Completed changelog automation Phases 1-3 (127 PR entries recovered, PRs #1281/#1315 merged to develop), finalized project status docs (README.md, PROJECT_PLAN.md, PHASE_4_KICKOFF.md with 4A-4D sub-tasks), all changes committed to develop.
+
+## 12:37 | develop
+
+Phase 3 labeling consolidation: consolidated labeling.yml, dependabot-security-label.yml, issue-close-label-hygiene.yml → labeling-governance.yml; PR #1319 merged to develop; created tracking issues #1360-#1363; disabled legacy workflows for 24h monitoring.
+
+## [TIME] | refactor/repo-restructuring-2026-07-25
+
+Repo restructuring project initialized: renamed branch per governance, created 12 docs (SPECIFICATION.md, PREFLIGHT_CHECKLIST.md, 7 PHASE-*.md prompts, project README/INDEX, continuation prompt), fixed 185 lint issues, created PR #1384; Phase 1.A ready.
+
+## 12:43 | test/feat-labeling-test-1
+
+Merged PR #1367 (Phase 3.1 labeling consolidation): consolidated 3 workflows→1 via labeling-governance.yml (47% reduction, 204 lines eliminated); Phase 3.2 test plan prepared (5 scenarios, 14 test cases, branches test/labeling-consolidation-integration & test/feat-labeling-test-1); staged 9 active proj planning files + workflow for develop PR.
+Perfect! Here's the final cleanup command and session summary:
+
+---
+
+## 🎬 Session Closing Checklist
+
+### ✅ Worktree Cleanup (Run this command to finalize)
+
+```bash
+git worktree remove /Users/ash/Studio/LightSpeedWP.Agency/.github/.claude/worktrees/pr-merge-request-bc86aa
+```
+
+This will remove the worktree safely and clean up the `.claude/worktrees/` directory.
+
+---
+
+## 📊 Session Summary
+
+**Duration:** Full conversation (context reset once)  
+**Branch:** `refactor/repo-restructuring-2026-07-25`  
+**PR:** #1384  
+**Commits:** 2  
+
+### ✅ Deliverables Completed
+
+1. **Phase 0 Documentation** (4 files, 1,330+ lines)
+   - SPECIFICATION.md — Complete project spec
+   - PREFLIGHT_CHECKLIST.md — Validation checklist
+   - README.md — Project overview
+   - INDEX.md — Document navigation
+
+2. **Phase 1–5 Execution Prompts** (7 files, 24,400+ tokens)
+   - Copy-paste ready for future Claude sessions
+   - Phase-by-phase breakdown
+   - Clear ownership matrix (manual vs. automated)
+
+3. **Project Management Infrastructure** (2 files)
+   - Global projects index
+   - RESTRUCTURING-CONTINUATION-PROMPT.md — For future sessions
+
+### 📈 Impact
+
+- 13 files created
+- ~9,000 lines of documentation
+- 2 commits to PR #1384
+- 1 branch properly named per governance
+- All markdown linting passed (185→0 issues)
+
+---
+
+## 🚀 For Next Session
+
+**Use this prompt to continue:**
+
+```
+cat RESTRUCTURING-CONTINUATION-PROMPT.md
+```
+
+Copy the entire file content into your next Claude Code session to:
+
+1. Create parent epic + 6 child phase issues
+2. Execute Phase 1.A (manual folder moves)
+3. Continue with phases 1.B–5 via automated prompts
+
+---
+
+## 💾 Daily Log Entry
+
+```
+## 13:48 | refactor/repo-restructuring-2026-07-25
+Created Phase 0–5 project documentation for `.github` repo restructuring: SPECIFICATION.md, PREFLIGHT_CHECKLIST.md, 7 phase execution prompts (24.4k tokens), continuation prompt for future session, and global projects index. PR #1384 ready for merge; worktree to be removed after cleanup command execution.
+```
+
+---
+
+**Ready to wrap up? Run the worktree removal command above, and this session is closed! 🎯**
+
+## 12:49 | develop
+
+Merged labeling-governance.yml consolidation (PR #1319) to develop; created issues #1360-#1363; Phase 3.3 deprecation underway.
+
+## 12:53 | test/feat-labeling-test-1
+
+Merged PR #1367 (labeling-gov consolidation) to develop; created test/feat-labeling-test-1 for Phase 3.2 w/ test plans (5 scenarios, 14 tests); staged PR #1390 for project docs.

--- a/.remember/now.md
+++ b/.remember/now.md
@@ -96,3 +96,11 @@ Built comprehensive issue triage automation system in PR #1377 with milestone-as
 ## 12:17 | docs/workflows-consolidation-phase-2-documentation
 
 Phase 2 workflows-consol complete (merged PRs #1313 documentation.yml, #1317 cleanup); addressed CodeRabbit feedback (PR #1387 security-fixes, Issue #1386); committed PHASE_2_3_TEST_EXECUTION_PLAN.md, PHASE_2_COMPLETION_SUMMARY.md, PHASE_3_LABELING_CONSOLIDATION_PLAN.md to develop.
+
+## 12:28 | develop
+
+Phase 3.1: Merged PR #1319 (labeling-gov.yml consolidates 3 workflows), disabled legacy workflows, opened tracking issues #1360-#1363.
+
+## 12:36 | test/feat-labeling-test-1
+
+Committed Phase 3.2 test plan + 8 active project planning docs (commit 76fb9ad94), push to develop blocked by release.agent.js test validation failures in pre-push hooks.

--- a/.remember/phase-3.2-execution-continuation.md
+++ b/.remember/phase-3.2-execution-continuation.md
@@ -1,26 +1,31 @@
 # Phase 3.2 Integration Testing — Execution Continuation Prompt
 
-## Current State (2026-07-26 12:13 UTC)
+## Current State (2026-07-26 15:45 UTC)
 
 **Project:** GitHub Workflows Consolidation Initiative (Epic #1227)  
 **Phase:** 3.2 — Integration Testing — Labeling Governance Consolidation  
-**Status:** KICKOFF COMPLETE — READY FOR TEST EXECUTION
+**Status:** PROJECT PLANNING COMPLETE — AWAITING PR MERGE
 
 ### ✅ Phase 3.1: COMPLETE & MERGED
 
 - PR #1367 merged to develop (2026-07-24T18:37:14Z)
-- New consolidated workflow: `.github/workflows/labeling-governance.yml` (226 lines)
+- New consolidated workflow: `.github/workflows/labeling-governance.yml` (226 lines, LIVE)
 - Consolidated from: `labeling.yml` + `dependabot-security-label.yml` + `issue-close-label-hygiene.yml`
 - Code reduction: ~204 lines eliminated (47% deduplication)
 
-### 🚀 Phase 3.2: KICKOFF COMPLETE — TEST DOCUMENTATION CREATED
+### ✅ Phase 3.2: PROJECT PLANNING COMPLETE — PR #1390 PENDING MERGE
 
 **Test Branch:** `test/feat-labeling-test-1`  
-**Documentation Commit:** b126131b1  
+**Project Planning PR:** [#1390](https://github.com/lightspeedwp/.github/pull/1390)  
+**Documentation Commits:** b126131b1, 76fb9ad94  
 **Files Created:**
 
-- `.github/projects/active/workflows-consolidation-2026-q3/PHASE_3.2_TEST_PLAN.md` ✓ Committed & pushed
-- `.github/projects/active/workflows-consolidation-2026-q3/PHASE_3_PROGRESS.md` ✓ Committed & pushed
+- `.github/projects/active/workflows-consolidation-2026-q3/PHASE_3.2_TEST_PLAN.md` ✓ Committed
+- `.github/projects/active/workflows-consolidation-2026-q3/PHASE_3_PROGRESS.md` ✓ Committed
+- `.github/projects/active/workflows-consolidation-2026-q3/PHASE_2_3_INTEGRATION_TESTING.md` ✓ In PR #1390
+- `.github/projects/active/workflows-consolidation-2026-q3/PHASE_3_STATUS.md` ✓ In PR #1390
+- `.github/workflows/labeling-governance.yml` ✓ In PR #1390 (Phase 3.1 deliverable)
+- Project planning files for Agent Standards, Changelog Hardening, Phase 2B Skills ✓ In PR #1390
 
 **Documentation Location:**
 

--- a/.schemas/agent-capability-manifest.schema.json
+++ b/.schemas/agent-capability-manifest.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/lightspeedwp/.github/develop/schema/agent-capability-manifest.schema.json",
+  "title": "Agent Capability Manifest Schema",
+  "description": "Validates an agent's declared capabilities, prerequisites, constraints, and performance targets.",
+  "type": "object",
+  "required": ["capabilities"],
+  "properties": {
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "category": {
+            "type": "string",
+            "enum": ["core", "optional", "analysis", "reporting"]
+          },
+          "requires": {
+            "type": "object",
+            "properties": {
+              "libraries": { "type": "array", "items": { "type": "string" } },
+              "nodejs_version": { "type": "string" },
+              "memory_mb": { "type": "integer", "minimum": 0 },
+              "dependencies": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "storage_mb": { "type": "integer", "minimum": 0 }
+            },
+            "additionalProperties": false
+          },
+          "performance_targets": {
+            "type": "object",
+            "properties": {
+              "max_latency_ms": { "type": "integer", "minimum": 0 },
+              "throughput_tests_per_minute": { "type": "integer", "minimum": 0 }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "constraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "rule"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "data_access",
+              "timeout",
+              "network",
+              "resource",
+              "security"
+            ]
+          },
+          "rule": { "type": "string" },
+          "scope": {
+            "type": "string",
+            "enum": ["strict", "moderate", "permissive", "restricted"]
+          },
+          "value": {}
+        },
+        "additionalProperties": false
+      }
+    },
+    "security_rules": { "type": "array", "items": { "type": "string" } },
+    "performance_targets": {
+      "type": "object",
+      "properties": {
+        "agent_initialization_ms": { "type": "integer", "minimum": 0 },
+        "test_execution_overhead_ms": { "type": "integer", "minimum": 0 },
+        "memory_usage_mb": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": true
+}

--- a/.schemas/agent-config.schema.json
+++ b/.schemas/agent-config.schema.json
@@ -1,0 +1,247 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LightSpeedWP Unified Branding Agent Configuration Schema",
+  "description": "Configuration schema for the unified branding agent, defining document categories, frontmatter requirements, footer templates, and badge schemas",
+  "type": "object",
+  "definitions": {
+    "category": {
+      "type": "string",
+      "enum": [
+        "root",
+        "github-config",
+        "workflows",
+        "wceu-talk",
+        "tests",
+        "skills",
+        "scripts",
+        "plugins",
+        "instructions",
+        "hooks",
+        "documentation",
+        "cookbook",
+        "ai-configs",
+        "agent-specs",
+        "slides"
+      ]
+    },
+    "requiredFrontmatterFields": {
+      "type": "object",
+      "properties": {
+        "file_type": {
+          "type": "string",
+          "description": "Type of file (report, documentation, instruction, agent, skill, etc.)"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title of the document"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 datetime of last update (must be current for changed content)"
+        }
+      },
+      "required": ["file_type", "title", "last_updated"]
+    },
+    "optionalFrontmatterFields": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Brief description of document purpose"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+(\\.\\d+)?$",
+          "description": "Semantic version string (e.g., 1.0 or 1.2.3)"
+        },
+        "created_date": {
+          "type": "string",
+          "format": "date",
+          "description": "ISO date when file was created"
+        },
+        "owners": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of file owners/maintainers"
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "maxItems": 8,
+          "description": "Keywords for discoverability (max 8 tags)"
+        },
+        "category": {
+          "$ref": "#/definitions/category",
+          "description": "Document category for footer/badge selection"
+        },
+        "domain": {
+          "type": "string",
+          "description": "Domain or functional area"
+        },
+        "stability": {
+          "type": "string",
+          "enum": ["stable", "experimental", "incubating", "deprecated"],
+          "description": "Maturity level of the content"
+        },
+        "maintainer": {
+          "type": "string",
+          "description": "Primary maintainer or team responsible for updates"
+        },
+        "license": {
+          "type": "string",
+          "description": "License identifier (e.g., GPL-3.0, MIT)"
+        }
+      }
+    },
+    "categoryFooterTemplate": {
+      "type": "object",
+      "properties": {
+        "category": { "$ref": "#/definitions/category" },
+        "footer_format": {
+          "type": "string",
+          "description": "Template string for footer generation"
+        },
+        "variations": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Alternative footer formats for this category"
+        }
+      }
+    },
+    "badgeSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["status", "category", "version", "review", "maintenance"],
+          "description": "Badge type/category"
+        },
+        "placement": {
+          "type": "string",
+          "enum": ["header", "footer", "inline"],
+          "description": "Recommended badge placement"
+        },
+        "template": {
+          "type": "string",
+          "description": "Badge template (Markdown image syntax)"
+        }
+      }
+    }
+  },
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version"
+    },
+    "categories": {
+      "type": "object",
+      "description": "Document category definitions with paths and metadata",
+      "properties": {
+        "root": {
+          "type": "object",
+          "description": "Root-level GitHub configuration files",
+          "properties": {
+            "path_pattern": { "type": "string" },
+            "footer_required": { "type": "boolean" },
+            "badge_support": { "type": "boolean" }
+          }
+        },
+        "github-config": {
+          "type": "object",
+          "description": ".github/ directory files (templates, workflows, config)",
+          "properties": {
+            "path_pattern": { "type": "string" },
+            "footer_required": { "type": "boolean" },
+            "badge_support": { "type": "boolean" }
+          }
+        },
+        "workflows": {
+          "type": "object",
+          "description": "GitHub Actions workflow files",
+          "properties": {
+            "path_pattern": { "type": "string" },
+            "footer_required": { "type": "boolean" },
+            "badge_support": { "type": "boolean" }
+          }
+        },
+        "skills": {
+          "type": "object",
+          "description": "Portable skill definitions (highest priority for remediation)",
+          "properties": {
+            "path_pattern": { "type": "string" },
+            "footer_required": { "type": "boolean" },
+            "badge_support": { "type": "boolean" }
+          }
+        },
+        "instructions": {
+          "type": "object",
+          "description": "Portable instruction files",
+          "properties": {
+            "path_pattern": { "type": "string" },
+            "footer_required": { "type": "boolean" },
+            "badge_support": { "type": "boolean" }
+          }
+        },
+        "plugins": {
+          "type": "object",
+          "description": "Plugin definitions and packages",
+          "properties": {
+            "path_pattern": { "type": "string" },
+            "footer_required": { "type": "boolean" },
+            "badge_support": { "type": "boolean" }
+          }
+        },
+        "documentation": {
+          "type": "object",
+          "description": "Documentation and guides",
+          "properties": {
+            "path_pattern": { "type": "string" },
+            "footer_required": { "type": "boolean" },
+            "badge_support": { "type": "boolean" }
+          }
+        },
+        "agent-specs": {
+          "type": "object",
+          "description": "Agent specification files",
+          "properties": {
+            "path_pattern": { "type": "string" },
+            "footer_required": { "type": "boolean" },
+            "badge_support": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "frontmatter_rules": {
+      "type": "object",
+      "description": "Frontmatter validation and transformation rules",
+      "properties": {
+        "required_fields": {
+          "$ref": "#/definitions/requiredFrontmatterFields"
+        },
+        "optional_fields": {
+          "$ref": "#/definitions/optionalFrontmatterFields"
+        },
+        "field_defaults": {
+          "type": "object",
+          "description": "Default values for fields per category"
+        },
+        "validation_rules": {
+          "type": "object",
+          "description": "Validation constraints per field and category"
+        }
+      }
+    },
+    "footer_templates": {
+      "type": "object",
+      "description": "Category-specific footer templates",
+      "additionalProperties": { "$ref": "#/definitions/categoryFooterTemplate" }
+    },
+    "badge_schemas": {
+      "type": "object",
+      "description": "Badge definitions by type and category",
+      "additionalProperties": { "$ref": "#/definitions/badgeSchema" }
+    }
+  },
+  "required": ["version"]
+}

--- a/.schemas/agent-plugin-binding.schema.json
+++ b/.schemas/agent-plugin-binding.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/lightspeedwp/.github/develop/schema/agent-plugin-binding.schema.json",
+  "title": "Agent-Plugin Binding Schema",
+  "description": "Validates the relationship and wiring between agents and the plugin that packages them.",
+  "type": "object",
+  "required": ["plugin_id"],
+  "properties": {
+    "plugin_id": { "type": "string", "pattern": "^lightspeed-[a-z0-9-]+$" },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["agent_id", "path"],
+        "properties": {
+          "agent_id": { "type": "string" },
+          "path": { "type": "string" },
+          "required_skills": { "type": "array", "items": { "type": "string" } },
+          "required_hooks": { "type": "array", "items": { "type": "string" } },
+          "provider_support": {
+            "type": "object",
+            "properties": {
+              "claude": { "type": "boolean" },
+              "copilot": { "type": "boolean" },
+              "openai": { "type": "boolean" },
+              "gemini": { "type": "boolean" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string" },
+          "path": { "type": "string" },
+          "providers": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    },
+    "hooks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string" },
+          "path": { "type": "string" },
+          "triggers": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/.schemas/branding-schema.json
+++ b/.schemas/branding-schema.json
@@ -1,0 +1,291 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LightSpeed Unified Branding Schema",
+  "description": "Comprehensive schema for category-aware branding, frontmatter validation, header/footer management, and badge conventions for all document types in the LightSpeed .github repository",
+  "type": "object",
+  "required": [
+    "version",
+    "categories",
+    "frontmatter_fields",
+    "category_inference_rules"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version (semantic versioning)",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "created_date": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this schema was created"
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this schema was last updated"
+    },
+    "categories": {
+      "type": "object",
+      "description": "Complete definition of all 16 document categories with metadata, templates, and rules",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "name",
+          "description",
+          "file_patterns",
+          "frontmatter_required",
+          "header_behavior"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Human-readable category name"
+          },
+          "description": {
+            "type": "string",
+            "description": "Purpose and scope of documents in this category"
+          },
+          "audience": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Target audience for this document type"
+          },
+          "file_patterns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Path patterns for automatic category inference (glob patterns)"
+          },
+          "priority": {
+            "type": "integer",
+            "description": "Priority order for path-based inference (lower = higher priority)",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "frontmatter_required": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of required frontmatter fields for this category"
+          },
+          "frontmatter_optional": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of optional but recommended frontmatter fields"
+          },
+          "header_behavior": {
+            "type": "string",
+            "enum": ["required", "optional", "omitted"],
+            "description": "Whether headers should be required, optional, or omitted"
+          },
+          "header_fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Fields to include in generated headers"
+          },
+          "footer_behavior": {
+            "type": "string",
+            "enum": ["required", "optional", "minimal"],
+            "description": "Footer insertion and enforcement level"
+          },
+          "allowed_footers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of footer template IDs allowed for this category"
+          },
+          "default_footer": {
+            "type": "string",
+            "description": "Default footer template ID for this category"
+          },
+          "badge_conventions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Standard badges used to mark documents in this category"
+          },
+          "fallback_rules": {
+            "type": "object",
+            "description": "Rules for handling missing metadata",
+            "properties": {
+              "missing_frontmatter": {
+                "type": "string",
+                "enum": ["infer_from_path", "use_defaults", "skip_validation"],
+                "description": "How to handle documents with missing frontmatter"
+              },
+              "missing_header": {
+                "type": "string",
+                "enum": ["insert_auto", "skip", "warn"],
+                "description": "How to handle documents that should have headers"
+              },
+              "missing_footer": {
+                "type": "string",
+                "enum": ["insert_auto", "skip", "warn"],
+                "description": "How to handle documents that should have footers"
+              },
+              "category_inference": {
+                "type": "string",
+                "description": "Default category to use if inference fails"
+              }
+            }
+          },
+          "validation_rules": {
+            "type": "object",
+            "description": "Category-specific validation rules",
+            "properties": {
+              "max_header_lines": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "max_footer_lines": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "require_category_in_frontmatter": {
+                "type": "boolean"
+              },
+              "allow_duplicate_footers": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      }
+    },
+    "frontmatter_fields": {
+      "type": "object",
+      "description": "Complete definition of all frontmatter fields",
+      "properties": {
+        "required_fields": {
+          "type": "object",
+          "description": "Fields that must be present in all documents",
+          "additionalProperties": {
+            "$ref": "#/definitions/frontmatterField"
+          }
+        },
+        "optional_fields": {
+          "type": "object",
+          "description": "Fields that may be present in documents",
+          "additionalProperties": {
+            "$ref": "#/definitions/frontmatterField"
+          }
+        }
+      }
+    },
+    "category_inference_rules": {
+      "type": "object",
+      "description": "Rules for inferring category from file path and frontmatter",
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["frontmatter_first", "path_first", "hybrid"],
+          "description": "Priority strategy for category determination"
+        },
+        "path_priority": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pattern": {
+                "type": "string",
+                "description": "Glob pattern to match file paths"
+              },
+              "category": {
+                "type": "string",
+                "description": "Inferred category for matching paths"
+              },
+              "priority": {
+                "type": "integer",
+                "description": "Priority order (lower = higher priority)"
+              }
+            }
+          },
+          "description": "Path-based category inference rules in priority order"
+        },
+        "fallback_category": {
+          "type": "string",
+          "description": "Default category if no inference rules match"
+        }
+      }
+    },
+    "validation_rules": {
+      "type": "object",
+      "description": "Global validation rules applied across all categories",
+      "properties": {
+        "max_frontmatter_size_bytes": {
+          "type": "integer",
+          "description": "Maximum size of frontmatter block in bytes"
+        },
+        "enforce_category_in_frontmatter": {
+          "type": "boolean",
+          "description": "Whether category field is required in frontmatter"
+        },
+        "allow_multiple_footers": {
+          "type": "boolean",
+          "description": "Whether a single document can have multiple footers"
+        },
+        "max_footer_lines": {
+          "type": "integer",
+          "description": "Global maximum lines in a footer"
+        },
+        "require_updated_date": {
+          "type": "boolean",
+          "description": "Whether last_updated date is required"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "frontmatterField": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["string", "array", "object", "boolean", "number", "date"],
+          "description": "Data type of the field"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this field"
+        },
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern for validation (strings only)"
+        },
+        "enum": {
+          "type": "array",
+          "description": "Allowed values for this field"
+        },
+        "format": {
+          "type": "string",
+          "enum": ["date", "date-time", "email", "uri"],
+          "description": "Format validation for specific types"
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Minimum length for string fields"
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum length for string fields"
+        },
+        "example": {
+          "description": "Example value for this field"
+        }
+      }
+    }
+  }
+}

--- a/.schemas/changelog.schema.json
+++ b/.schemas/changelog.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lightspeedwp.com/schemas/changelog.schema.json",
+  "title": "Changelog Schema",
+  "description": "JSON schema for validating Keep a Changelog format CHANGELOG.md files",
+  "type": "object",
+  "properties": {
+    "releases": {
+      "type": "array",
+      "description": "List of all releases in the changelog",
+      "items": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string",
+            "pattern": "^(Unreleased|\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)$",
+            "description": "Version number or 'Unreleased'",
+            "examples": ["Unreleased", "1.0.0", "0.1.0", "2.1.3-alpha"]
+          },
+          "date": {
+            "type": "string",
+            "pattern": "^(\\d{4}-\\d{2}-\\d{2}|DD-MM-YYYY|YYYY-MM-DD)$",
+            "description": "Release date in YYYY-MM-DD format or placeholder",
+            "examples": ["2025-11-17", "DD-MM-YYYY", "YYYY-MM-DD"]
+          },
+          "sections": {
+            "type": "object",
+            "description": "Changelog sections following Keep a Changelog format",
+            "properties": {
+              "added": {
+                "type": "array",
+                "description": "New features added",
+                "items": { "type": "string" }
+              },
+              "changed": {
+                "type": "array",
+                "description": "Changes in existing functionality",
+                "items": { "type": "string" }
+              },
+              "deprecated": {
+                "type": "array",
+                "description": "Soon-to-be removed features",
+                "items": { "type": "string" }
+              },
+              "removed": {
+                "type": "array",
+                "description": "Removed features",
+                "items": { "type": "string" }
+              },
+              "fixed": {
+                "type": "array",
+                "description": "Bug fixes",
+                "items": { "type": "string" }
+              },
+              "security": {
+                "type": "array",
+                "description": "Security fixes and improvements",
+                "items": { "type": "string" }
+              },
+              "documentation": {
+                "type": "array",
+                "description": "Documentation changes",
+                "items": { "type": "string" }
+              },
+              "performance": {
+                "type": "array",
+                "description": "Performance improvements",
+                "items": { "type": "string" }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "required": ["version", "date"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "format": {
+      "type": "string",
+      "enum": ["keepachangelog"],
+      "description": "Changelog format standard"
+    },
+    "semver": {
+      "type": "boolean",
+      "description": "Whether the project follows Semantic Versioning"
+    }
+  },
+  "required": ["releases"],
+  "additionalProperties": true
+}

--- a/.schemas/coderabbit-overrides.v2.json
+++ b/.schemas/coderabbit-overrides.v2.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CodeRabbit Overrides v2",
+  "type": "object",
+  "properties": {
+    "reviews": {
+      "type": "object",
+      "properties": {
+        "path_filters": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["path_filters"]
+    }
+  },
+  "required": ["reviews"]
+}

--- a/.schemas/footer-config.schema.json
+++ b/.schemas/footer-config.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Footer Configuration Schema",
+  "description": "Defines valid footer templates by document category, enforcing a single footer per document and preventing duplicates",
+  "type": "object",
+  "required": ["version", "categories", "footers"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version for tracking changes",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "categories": {
+      "type": "object",
+      "description": "Document category definitions with allowed footer types",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["name", "allowed_footers", "default_footer"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Human-readable category name"
+          },
+          "description": {
+            "type": "string",
+            "description": "What documents in this category are for"
+          },
+          "allowed_footers": {
+            "type": "array",
+            "description": "List of valid footer IDs for this category",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "default_footer": {
+            "type": "string",
+            "description": "Default footer ID if not specified in frontmatter"
+          }
+        }
+      }
+    },
+    "footers": {
+      "type": "object",
+      "description": "Predefined footer templates by ID",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["id", "name", "template"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique footer identifier (kebab-case)",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable footer name"
+          },
+          "template": {
+            "type": "string",
+            "description": "Footer markdown template (may contain variables like {contributors_url}, {contact_url})"
+          },
+          "variables": {
+            "type": "object",
+            "description": "Variable substitutions available in this footer",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "emoji_only": {
+            "type": "boolean",
+            "description": "If true, footer uses emoji as primary visual element (accessibility concern)",
+            "default": false
+          },
+          "accessibility_notes": {
+            "type": "string",
+            "description": "WCAG compliance notes or warnings"
+          }
+        }
+      }
+    },
+    "validation_rules": {
+      "type": "object",
+      "description": "Rules for footer validation",
+      "properties": {
+        "max_footer_lines": {
+          "type": "integer",
+          "description": "Maximum lines allowed in a footer",
+          "default": 5,
+          "minimum": 1
+        },
+        "max_duplicates_allowed": {
+          "type": "integer",
+          "description": "Maximum consecutive duplicate footers before failing validation (prevent copy-paste errors)",
+          "default": 0,
+          "minimum": 0
+        },
+        "require_category_in_frontmatter": {
+          "type": "boolean",
+          "description": "If true, documents must declare a category in frontmatter",
+          "default": true
+        },
+        "allow_multiple_footers_per_document": {
+          "type": "boolean",
+          "description": "If false, documents can only have one footer (recommended: true)",
+          "default": false
+        }
+      }
+    }
+  }
+}

--- a/.schemas/frontmatter.schema.json
+++ b/.schemas/frontmatter.schema.json
@@ -1,0 +1,819 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LightSpeedWP Unified Frontmatter Schema",
+  "description": "Unified frontmatter schema combining LightSpeed governance requirements with awesome-copilot conventions for all .github files. Supports GitHub templates, Copilot instructions, prompts, agents, and documentation.",
+  "type": "object",
+  "definitions": {
+    "commonFields": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Human-readable title"
+        },
+        "description": {
+          "type": "string",
+          "description": "Brief description of purpose (required for most file types)"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version string (e.g., v1.1)"
+        },
+        "created_date": {
+          "type": "string",
+          "format": "date",
+          "description": "ISO date when file was created"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "date",
+          "description": "ISO date of last update"
+        },
+        "author": {
+          "type": "string",
+          "description": "Main author or responsible party"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "instruction",
+            "information",
+            "conversation",
+            "template",
+            "reference",
+            "agent",
+            "ask",
+            "edit"
+          ],
+          "description": "Operational or content mode"
+        },
+        "maintainer": {
+          "type": "string",
+          "description": "Current maintainer or team"
+        },
+        "owners": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of owners/maintainers"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 8,
+          "description": "Keywords for discovery/filtering (max 8)"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["active", "deprecated", "draft", "experimental"],
+          "description": "Current status"
+        },
+        "stability": {
+          "type": "string",
+          "enum": ["stable", "experimental", "incubating"],
+          "description": "Maturity expectation"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "description": "Whether this file is deprecated"
+        },
+        "replacement": {
+          "type": "string",
+          "description": "Path to replacement file if deprecated"
+        },
+        "domain": {
+          "type": "string",
+          "enum": [
+            "wp-core",
+            "block-theme",
+            "plugin-hardening",
+            "perf",
+            "a11y",
+            "i18n",
+            "security",
+            "headless",
+            "generic",
+            "governance",
+            "awesome-copilot",
+            "lightspeed"
+          ],
+          "description": "Primary classification domain"
+        },
+        "extraDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Secondary classifications"
+        },
+        "license": {
+          "type": "string",
+          "description": "License identifier"
+        }
+      }
+    }
+  },
+  "discriminator": {
+    "propertyName": "file_type"
+  },
+  "oneOf": [
+    {
+      "title": "AGENTS.md (Main Agents Index)",
+      "description": "Main agents reference file.",
+      "properties": {
+        "file_type": {
+          "const": "agents-index"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "last_updated": {
+          "type": "string"
+        },
+        "owners": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "category": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type", "title", "description"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Agent Index (.github/agents/agent.md)",
+      "description": "Agent directory index file.",
+      "properties": {
+        "file_type": {
+          "const": "agent-index"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type", "title", "description"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Agent Specification (.github/agents/*.agent.md)",
+      "description": "Individual agent specification files. Supports both VS Code native format and LightSpeed extended format.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/commonFields"
+        }
+      ],
+      "properties": {
+        "file_type": {
+          "type": "string",
+          "enum": ["agent", "chatmode"],
+          "description": "File type identifier. 'chatmode' is deprecated and will be migrated to 'agent'."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable agent name (VS Code required field)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Brief description of agent purpose (VS Code required field)"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Available tools/capabilities (VS Code field). Values: codebase, search, usages, editFiles, fetchWebpage, findTestFiles, githubRepo, problems, runCommands, runNotebooks, runTasks, runTests, terminalLastCommand, terminalSelection, thinking, vscodeAPI, custom MCP tools"
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "read",
+              "write",
+              "execute",
+              "shell",
+              "filesystem",
+              "network",
+              "github:repo",
+              "github:issues",
+              "github:pulls",
+              "github:workflows",
+              "github:checks",
+              "github:actions"
+            ]
+          },
+          "description": "Explicit permissions or scopes required by the agent; complements `tools`."
+        },
+        "model": {
+          "type": "string",
+          "description": "Preferred AI model (optional VS Code field)"
+        },
+        "handoffs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "Button label for handoff"
+              },
+              "agent": {
+                "type": "string",
+                "description": "Target agent name"
+              },
+              "prompt": {
+                "type": "string",
+                "description": "Prompt to pass to target agent"
+              },
+              "send": {
+                "type": "boolean",
+                "description": "Auto-send the prompt",
+                "default": false
+              }
+            },
+            "required": ["label", "agent", "prompt"]
+          },
+          "description": "Handoff definitions for agent chaining (VS Code optional field)"
+        },
+        "version": {
+          "type": "string"
+        },
+        "last_updated": {
+          "type": "string"
+        },
+        "owners": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "category": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string",
+          "enum": ["vscode", "github-copilot", "cli"],
+          "description": "Target environment for the agent"
+        },
+        "visibility": {
+          "type": "string",
+          "enum": ["public", "private", "internal"],
+          "description": "Agent visibility scope"
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "guardrails": {
+              "type": "string",
+              "description": "Safety constraints"
+            }
+          },
+          "description": "Additional agent metadata"
+        },
+        "id": {
+          "type": "string",
+          "description": "Legacy chatmode identifier (deprecated, use 'name' instead)"
+        },
+        "title": {
+          "type": "string",
+          "description": "Legacy chatmode title (deprecated, use 'name' instead)"
+        },
+        "context_window": {
+          "type": "integer",
+          "description": "Token limit considerations (legacy chatmode field)"
+        },
+        "temperature": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 2,
+          "description": "AI response randomness setting (legacy chatmode field)"
+        },
+        "max_tokens": {
+          "type": "integer",
+          "description": "Response length limitations (legacy chatmode field)"
+        }
+      },
+      "required": ["description"],
+      "additionalProperties": true
+    },
+    {
+      "title": "JavaScript Agent File (.github/agents/*.agent.js)",
+      "description": "Node.js-based agent implementation.",
+      "properties": {
+        "file_type": {
+          "const": "agent-js"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Shell Agent File (.github/agents/*.agent.sh)",
+      "description": "Shell-based agent implementation.",
+      "properties": {
+        "file_type": {
+          "const": "agent-sh"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Python Agent File (.github/agents/*.agent.py)",
+      "description": "Python-based agent implementation.",
+      "properties": {
+        "file_type": {
+          "const": "agent-py"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Deprecated: Chatmodes Index (.github/chatmodes/chatmodes.md)",
+      "description": "DEPRECATED: GitHub has deprecated chatmodes in favour of agents. This file type is preserved for backward compatibility only.",
+      "properties": {
+        "file_type": {
+          "const": "chatmode-index"
+        },
+        "title": {
+          "type": "string"
+        },
+        "deprecated": {
+          "const": true
+        }
+      },
+      "required": ["file_type", "title"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Custom Instructions (.github/custom-instructions.md)",
+      "description": "Main instructions file.",
+      "properties": {
+        "file_type": {
+          "const": "custom-instructions"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type", "title", "description"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Instructions File (.github/instructions/*.instructions.md)",
+      "description": "Instructions for contributors, bots, or Copilot with LightSpeed governance and awesome-copilot conventions.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/commonFields"
+        }
+      ],
+      "properties": {
+        "file_type": {
+          "const": "instructions"
+        },
+        "description": {
+          "type": "string"
+        },
+        "applyTo": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Glob patterns for files this applies to (awesome-copilot style)"
+        },
+        "apply_to": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Alias for applyTo (LightSpeed legacy)"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["agent", "ask"],
+          "description": "Execution style for Copilot"
+        },
+        "domain": {
+          "$ref": "#/definitions/commonFields/properties/domain"
+        },
+        "stability": {
+          "$ref": "#/definitions/commonFields/properties/stability"
+        },
+        "deprecated": {
+          "$ref": "#/definitions/commonFields/properties/deprecated"
+        },
+        "replacement": {
+          "$ref": "#/definitions/commonFields/properties/replacement"
+        }
+      },
+      "required": ["file_type", "description"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Prompts Index (.github/prompts/prompts.md)",
+      "description": "Prompts index file.",
+      "properties": {
+        "file_type": {
+          "const": "prompt-index"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type", "title"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Prompt Specification (.github/prompts/*.prompt.md)",
+      "description": "Prompt files for Copilot and bots with awesome-copilot conventions.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/commonFields"
+        }
+      ],
+      "properties": {
+        "file_type": {
+          "const": "prompt"
+        },
+        "description": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["ask", "edit", "agent"],
+          "description": "Copilot execution mode"
+        },
+        "model": {
+          "type": "string",
+          "description": "Preferred AI model"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Available tools/capabilities"
+        },
+        "domain": {
+          "$ref": "#/definitions/commonFields/properties/domain"
+        },
+        "stability": {
+          "$ref": "#/definitions/commonFields/properties/stability"
+        },
+        "deprecated": {
+          "$ref": "#/definitions/commonFields/properties/deprecated"
+        },
+        "replacement": {
+          "$ref": "#/definitions/commonFields/properties/replacement"
+        }
+      },
+      "required": ["file_type", "description"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Issue Template (.github/ISSUE_TEMPLATE/*.md)",
+      "description": "Templates for GitHub issues.",
+      "properties": {
+        "file_type": {
+          "const": "issue-template"
+        },
+        "name": {
+          "type": "string"
+        },
+        "about": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type", "name", "about"],
+      "not": {
+        "required": ["description"]
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "Pull Request Template (.github/PULL_REQUEST_TEMPLATE/*.md)",
+      "description": "Templates for GitHub PRs.",
+      "properties": {
+        "file_type": {
+          "const": "pr-template"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type", "title", "description"],
+      "not": {
+        "required": ["about"]
+      },
+      "additionalProperties": true
+    },
+    {
+      "title": "Discussion Template (.github/DISCUSSION_TEMPLATES/*.yml)",
+      "description": "Templates for GitHub Discussions.",
+      "properties": {
+        "file_type": {
+          "const": "discussion-template"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type", "name", "description"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Saved Replies Index (.github/SAVED_REPLIES.md)",
+      "description": "Index file for all saved replies.",
+      "properties": {
+        "file_type": {
+          "const": "saved-replies-index"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type", "title"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Saved Reply (.github/SAVED_REPLIES/*.md)",
+      "description": "Individual saved reply files.",
+      "properties": {
+        "file_type": {
+          "const": "saved-reply"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": ["file_type", "title"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Deprecated: Chatmode (.github/chatmodes/*.chatmode.md)",
+      "description": "DEPRECATED: GitHub has deprecated chatmodes in favour of agents. Use .agent.md files instead. This schema is preserved for backward compatibility only.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/commonFields"
+        }
+      ],
+      "properties": {
+        "file_type": {
+          "const": "chatmode"
+        },
+        "description": {
+          "type": "string"
+        },
+        "deprecated": {
+          "const": true,
+          "description": "Chatmodes are deprecated; migrate to agents"
+        },
+        "replacement": {
+          "type": "string",
+          "description": "Path to replacement agent file"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["instruction", "conversation", "template", "information"],
+          "description": "Chatmode operational mode (deprecated)"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Available tools/capabilities"
+        },
+        "model": {
+          "type": "string",
+          "description": "Preferred AI model"
+        },
+        "context_window": {
+          "type": "integer",
+          "description": "Token limit considerations"
+        },
+        "temperature": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 2,
+          "description": "AI response randomness setting"
+        },
+        "max_tokens": {
+          "type": "integer",
+          "description": "Response length limitations"
+        },
+        "domain": {
+          "$ref": "#/definitions/commonFields/properties/domain"
+        },
+        "stability": {
+          "$ref": "#/definitions/commonFields/properties/stability"
+        },
+        "deprecated": {
+          "$ref": "#/definitions/commonFields/properties/deprecated"
+        },
+        "replacement": {
+          "$ref": "#/definitions/commonFields/properties/replacement"
+        }
+      },
+      "required": ["file_type", "description"],
+      "additionalProperties": true
+    },
+    {
+      "title": "Documentation (docs/*.md)",
+      "description": "General documentation files.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/commonFields"
+        }
+      ],
+      "properties": {
+        "file_type": {
+          "const": "documentation"
+        },
+        "description": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["information", "instruction", "reference"],
+          "description": "Documentation type"
+        },
+        "domain": {
+          "$ref": "#/definitions/commonFields/properties/domain"
+        },
+        "stability": {
+          "$ref": "#/definitions/commonFields/properties/stability"
+        },
+        "deprecated": {
+          "$ref": "#/definitions/commonFields/properties/deprecated"
+        },
+        "replacement": {
+          "$ref": "#/definitions/commonFields/properties/replacement"
+        },
+        "created_date": {
+          "type": "string",
+          "format": "date",
+          "description": "Date when document was created"
+        },
+        "last_updated": {
+          "$ref": "#/definitions/commonFields/properties/last_updated"
+        }
+      },
+      "required": ["file_type", "description"],
+      "additionalProperties": true
+    },
+    {
+      "title": "README Files (README.md)",
+      "description": "Module and project README documentation files.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/commonFields"
+        }
+      ],
+      "properties": {
+        "file_type": {
+          "const": "readme"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "last_updated": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "license": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "domain": {
+          "$ref": "#/definitions/commonFields/properties/domain"
+        },
+        "stability": {
+          "$ref": "#/definitions/commonFields/properties/stability"
+        },
+        "deprecated": {
+          "$ref": "#/definitions/commonFields/properties/deprecated"
+        },
+        "replacement": {
+          "$ref": "#/definitions/commonFields/properties/replacement"
+        }
+      },
+      "required": ["file_type", "title", "description"],
+      "additionalProperties": true
+    }
+  ],
+  "examples": [
+    {
+      "$schema": "schemas/frontmatter.schema.json",
+      "file_type": "agent",
+      "name": "jsdoc-review",
+      "description": "Audits JS/TS code for JSDoc coverage.",
+      "version": "v0.2.0",
+      "last_updated": "2025-10-22",
+      "owners": ["lightspeedwp/maintainers"],
+      "status": "active",
+      "category": "documentation",
+      "domain": "generic",
+      "stability": "stable",
+      "tags": ["jsdoc", "lint"],
+      "tools": ["Read"]
+    },
+    {
+      "$schema": "schemas/frontmatter.schema.json",
+      "file_type": "instructions",
+      "description": "Security guidelines for WordPress REST API development",
+      "applyTo": "includes/api/**/*.php",
+      "domain": "security",
+      "stability": "stable",
+      "tags": ["security", "rest", "validation"]
+    }
+  ]
+}

--- a/.schemas/multi-provider-agent.schema.json
+++ b/.schemas/multi-provider-agent.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/lightspeedwp/.github/develop/schema/multi-provider-agent.schema.json",
+  "title": "Multi-Provider Agent Schema",
+  "description": "Validates the AGENT.md frontmatter of a multi-provider agent (Claude, GitHub Copilot, OpenAI).",
+  "type": "object",
+  "required": ["name", "description", "providers", "capabilities"],
+  "properties": {
+    "file_type": { "type": "string", "const": "agent" },
+    "name": { "type": "string", "description": "Human-readable agent name." },
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+    "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+    "status": {
+      "type": "string",
+      "enum": ["active", "deprecated", "draft", "experimental"]
+    },
+    "category": { "type": "string" },
+    "providers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": ["claude", "copilot", "openai", "gemini"]
+      },
+      "uniqueItems": true
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "tools": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Provider-agnostic tool identifiers."
+    },
+    "provider_overrides": {
+      "type": "object",
+      "properties": {
+        "claude": { "type": "object" },
+        "copilot": { "type": "object" },
+        "openai": { "type": "object" },
+        "gemini": { "type": "object" }
+      },
+      "additionalProperties": false
+    },
+    "requirements": { "type": "array", "items": { "type": "string" } },
+    "constraints": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": true
+}

--- a/.schemas/plugin-manifest.schema.json
+++ b/.schemas/plugin-manifest.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lightspeedwp.github.io/schemas/plugin-manifest.schema.json",
+  "title": "LightSpeed Plugin Manifest",
+  "description": "Validation schema for portable plugin manifests used by Claude, Codex, Copilot, and Gemini integrations.",
+  "type": "object",
+  "required": ["name", "version", "description"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "displayName": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "description": {
+      "type": "string"
+    },
+    "manifest_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "includes": {
+      "type": "object",
+      "properties": {
+        "skills": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": true
+}

--- a/.schemas/project-fields.schema.json
+++ b/.schemas/project-fields.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Schema for project-fields.yml defining project field archetypes",
+  "type": "object",
+  "required": ["schema", "types"],
+  "properties": {
+    "schema": {
+      "type": "integer",
+      "const": 1
+    },
+    "types": {
+      "type": "object",
+      "patternProperties": {
+        "^[A-Za-z0-9_]+$": {
+          "description": "Project field archetype keyed by values such as product_dev or client_services.",
+          "type": "object",
+          "required": ["project_name", "fields"],
+          "properties": {
+            "project_name": { "type": "string" },
+            "fields": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["key", "slug", "type"],
+                "properties": {
+                  "key": { "type": "string" },
+                  "slug": { "type": "string" },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "single_select",
+                      "text",
+                      "number",
+                      "date",
+                      "iteration"
+                    ]
+                  },
+                  "description": { "type": "string" },
+                  "options": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/.schemas/provider-config.schema.json
+++ b/.schemas/provider-config.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/lightspeedwp/.github/develop/schema/provider-config.schema.json",
+  "title": "Provider-Specific Configuration Schema",
+  "description": "Validates a per-provider tool/function definition file (claude/tools.json, openai/tools.json, copilot skill map).",
+  "type": "object",
+  "required": ["provider"],
+  "properties": {
+    "provider": {
+      "type": "string",
+      "enum": ["claude", "copilot", "openai", "gemini"]
+    },
+    "agent": { "type": "string" },
+    "type": { "type": "string" },
+    "instructions": { "type": "string" },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "input_schema": { "type": "object" },
+          "parameters": { "type": "object" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "functions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "parameters": { "type": "object" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "source": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "memory_config": { "type": "object" },
+    "security_rules": { "type": "array", "items": { "type": "string" } },
+    "response_format": {
+      "type": "string",
+      "enum": ["json", "markdown", "function_call", "text"]
+    }
+  },
+  "additionalProperties": true
+}

--- a/.schemas/quirky-footers.schema.json
+++ b/.schemas/quirky-footers.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Quirky Footers Configuration Schema",
+  "description": "Schema for validating quirky, category-specific footer templates with personality and charm",
+  "type": "object",
+  "required": ["version", "created_date", "categories", "footers"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semantic version of the quirky footers configuration"
+    },
+    "created_date": {
+      "type": "string",
+      "format": "date",
+      "description": "Date the configuration was first created"
+    },
+    "updated_date": {
+      "type": "string",
+      "format": "date",
+      "description": "Date the configuration was last updated"
+    },
+    "categories": {
+      "type": "object",
+      "description": "Mapping of document categories to quirky footer sets",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["name", "quirky_footers"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Human-readable category name"
+          },
+          "description": {
+            "type": "string",
+            "description": "What documents belong in this category"
+          },
+          "quirky_footers": {
+            "type": "array",
+            "minItems": 1,
+            "description": "List of quirky footer IDs available for this category",
+            "items": {
+              "type": "string"
+            }
+          },
+          "default_quirky_footer": {
+            "type": "string",
+            "description": "Default quirky footer ID if not specified in frontmatter"
+          }
+        }
+      }
+    },
+    "footers": {
+      "type": "object",
+      "description": "Quirky footer template definitions",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["id", "name", "template"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$",
+            "description": "Unique identifier for this footer (kebab-case)"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name of the footer"
+          },
+          "category": {
+            "type": "string",
+            "description": "Primary category this footer is designed for"
+          },
+          "template": {
+            "type": "string",
+            "description": "Markdown template for the footer. Must start with '---' separator."
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "playful",
+              "professional",
+              "quirky",
+              "encouraging",
+              "technical",
+              "welcoming"
+            ],
+            "description": "The tone/personality of this footer"
+          },
+          "emoji_count": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 5,
+            "description": "Number of emoji used in this footer (for accessibility tracking)"
+          },
+          "accessibility_notes": {
+            "type": "string",
+            "description": "Notes on accessibility considerations for this footer"
+          },
+          "min_doc_length": {
+            "type": "integer",
+            "description": "Minimum document length (in words) recommended for this footer"
+          }
+        }
+      }
+    },
+    "validation_rules": {
+      "type": "object",
+      "description": "Rules for footer validation",
+      "properties": {
+        "require_category_in_frontmatter": {
+          "type": "boolean",
+          "description": "Whether documents must declare their category in frontmatter"
+        },
+        "require_footer_in_document": {
+          "type": "boolean",
+          "description": "Whether documents must include a quirky footer"
+        },
+        "allow_custom_footer_in_frontmatter": {
+          "type": "boolean",
+          "description": "Whether documents can specify a custom footer via frontmatter"
+        },
+        "max_footer_lines": {
+          "type": "integer",
+          "description": "Maximum number of lines allowed in a footer"
+        },
+        "footer_randomization_enabled": {
+          "type": "boolean",
+          "description": "Whether to randomly rotate between category footers for variety"
+        }
+      }
+    },
+    "exclusion_patterns": {
+      "type": "object",
+      "description": "Patterns for files that should be exempt from footer requirements",
+      "properties": {
+        "vendor_paths": {
+          "type": "array",
+          "description": "Path patterns for embedded/vendor materials",
+          "items": {
+            "type": "string"
+          }
+        },
+        "system_files": {
+          "type": "array",
+          "description": "Path patterns for auto-generated or system files",
+          "items": {
+            "type": "string"
+          }
+        },
+        "archives": {
+          "type": "array",
+          "description": "Path patterns for archived or historical content",
+          "items": {
+            "type": "string"
+          }
+        },
+        "templates": {
+          "type": "array",
+          "description": "Path patterns for template scaffolds",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.schemas/schema-registry.json
+++ b/.schemas/schema-registry.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LightSpeed Portable Schema Registry",
+  "version": "v0.1.0",
+  "entries": [
+    {
+      "id": "frontmatter",
+      "path": "schema/frontmatter.schema.json",
+      "status": "active"
+    },
+    {
+      "id": "changelog",
+      "path": "schema/changelog.schema.json",
+      "status": "active"
+    },
+    {
+      "id": "project-fields",
+      "path": "schema/project-fields.schema.json",
+      "status": "active"
+    },
+    {
+      "id": "version",
+      "path": "schema/version.schema.json",
+      "status": "active"
+    },
+    {
+      "id": "skill-metadata",
+      "path": "schema/skill-metadata.schema.json",
+      "status": "active"
+    },
+    {
+      "id": "skill-agent-config",
+      "path": "schema/skill-agent-config.schema.json",
+      "status": "active"
+    },
+    {
+      "id": "plugin-manifest",
+      "path": "schema/plugin-manifest.schema.json",
+      "status": "active"
+    },
+    {
+      "id": "multi-provider-agent",
+      "path": "schema/multi-provider-agent.schema.json",
+      "status": "active"
+    },
+    {
+      "id": "agent-plugin-binding",
+      "path": "schema/agent-plugin-binding.schema.json",
+      "status": "active"
+    },
+    {
+      "id": "provider-config",
+      "path": "schema/provider-config.schema.json",
+      "status": "active"
+    },
+    {
+      "id": "agent-capability-manifest",
+      "path": "schema/agent-capability-manifest.schema.json",
+      "status": "active"
+    }
+  ]
+}

--- a/.schemas/skill-agent-config.schema.json
+++ b/.schemas/skill-agent-config.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lightspeedwp.github.io/schemas/skill-agent-config.schema.json",
+  "title": "LightSpeed Skill Platform Agent Config",
+  "description": "Per-platform skill configuration file for claude/copilot/gemini/codex/openai YAML files.",
+  "type": "object",
+  "required": ["interface", "policy"],
+  "properties": {
+    "interface": {
+      "type": "object",
+      "required": ["display_name", "short_description"],
+      "properties": {
+        "display_name": {
+          "type": "string"
+        },
+        "short_description": {
+          "type": "string"
+        },
+        "icon": {
+          "type": "string"
+        },
+        "brand_color": {
+          "type": "string",
+          "pattern": "^#[0-9A-Fa-f]{6}$"
+        },
+        "icon_small": {
+          "type": "string"
+        },
+        "icon_large": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "policy": {
+      "type": "object",
+      "required": ["products"],
+      "properties": {
+        "products": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["claude", "copilot", "gemini", "codex", "chatgpt", "api"]
+          },
+          "minItems": 1
+        },
+        "allow_implicit_invocation": {
+          "type": "boolean"
+        },
+        "compatibility_mode": {
+          "type": "string",
+          "enum": ["standard", "legacy-compatible", "experimental"]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/.schemas/skill-metadata.schema.json
+++ b/.schemas/skill-metadata.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lightspeedwp.github.io/schemas/skill-metadata.schema.json",
+  "title": "LightSpeed Skill Metadata",
+  "description": "Metadata contract for portable skills across Claude, Copilot, Gemini, Codex, and OpenAI integrations.",
+  "type": "object",
+  "required": ["name", "version", "description", "platforms"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^v\\d+\\.\\d+\\.\\d+$"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 10
+    },
+    "owners": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "platforms": {
+      "type": "object",
+      "required": ["claude", "copilot", "gemini", "codex"],
+      "properties": {
+        "claude": {
+          "$ref": "#/definitions/platform"
+        },
+        "copilot": {
+          "$ref": "#/definitions/platform"
+        },
+        "gemini": {
+          "$ref": "#/definitions/platform"
+        },
+        "codex": {
+          "$ref": "#/definitions/platform"
+        },
+        "openai": {
+          "$ref": "#/definitions/platform"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "platform": {
+      "type": "object",
+      "required": ["supported"],
+      "properties": {
+        "supported": {
+          "type": "boolean"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["first-class", "legacy-compatible", "experimental"]
+        },
+        "config": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/.schemas/version.schema.json
+++ b/.schemas/version.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lightspeedwp.com/schemas/version.schema.json",
+  "title": "Version Schema",
+  "description": "JSON schema for validating semantic version numbers in VERSION files",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "description": "Semantic version string (e.g., 1.0.0, 1.0.0-alpha, 1.0.0+build)",
+      "examples": [
+        "0.1.0",
+        "1.0.0",
+        "2.1.3",
+        "1.0.0-alpha",
+        "1.0.0-beta.1",
+        "1.0.0+20130313144700"
+      ]
+    }
+  },
+  "required": ["version"]
+}

--- a/scripts/validation/__tests__/validate-memory.test.js
+++ b/scripts/validation/__tests__/validate-memory.test.js
@@ -4,7 +4,7 @@ const path = require("path");
 const { execFileSync } = require("child_process");
 
 const scriptPath = path.join(__dirname, "../validate-memory.js");
-const repoRoot = path.resolve(__dirname, "../../../..");
+const repoRoot = path.resolve(__dirname, "../../..");
 
 function mkdirp(dir) {
   fs.mkdirSync(dir, { recursive: true });

--- a/scripts/validation/validate-agent-frontmatter.js
+++ b/scripts/validation/validate-agent-frontmatter.js
@@ -18,7 +18,7 @@ addFormats(ajv);
 // Load the unified frontmatter schema
 const schemaPath = path.join(
   __dirname,
-  "../../../.schemas/frontmatter.schema.json",
+  "../../.schemas/frontmatter.schema.json",
 );
 const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
 

--- a/scripts/validation/validate-agents.js
+++ b/scripts/validation/validate-agents.js
@@ -25,7 +25,7 @@ const AGENT_DIRS = [
   path.join(REPO_ROOT, "agents"),
   path.join(REPO_ROOT, ".github", "agents"),
 ].filter((dir) => fs.existsSync(dir));
-const SCHEMAS_DIR = path.join(REPO_ROOT, "schema");
+const SCHEMAS_DIR = path.join(REPO_ROOT, ".schemas");
 const WORKFLOWS_DIR = path.join(REPO_ROOT, ".github", "workflows");
 
 // Configuration


### PR DESCRIPTION
## Linked issues

Closes #1252
Closes #1253
Closes #1254
Closes #1256
Closes #1257

## Changelog

### Fixed
- Migrated all JSON schema files from `.github/schema/` to `.schemas/` (root) to complete the schema consolidation migration — resolves `validate-memory.test.js` test failures in downstream branches
- Updated `scripts/validation/validate-frontmatter.js`, `validate-agents.js`, and related scripts to resolve schema paths relative to repo root

## Testing steps

1. Run `npm run validate:frontmatter` — schemas resolve from `.schemas/` without errors
2. Run `npm run test` — `validate-memory.test.js` passes

### Checklist (Global DoD / PR)

- [x] All schema files present in `.schemas/`
- [x] Script path references updated to use `.schemas/` 
- [x] Tests pass locally
- [x] Follows `chore/` branch targeting `develop`