### PR TITLE
fix(ci): resolve checks.yml workflow validation error

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,10 +17,6 @@ on:
       - "package-lock.json"
       - ".nvmrc"
       - "*.md"
-    paths-ignore:
-      - ".github/reports/**"
-      - ".github/projects/**"
-      - ".github/tmp/**"
   push:
     branches: [develop]
     paths:
@@ -37,10 +33,6 @@ on:
       - "package-lock.json"
       - ".nvmrc"
       - "*.md"
-    paths-ignore:
-      - ".github/reports/**"
-      - ".github/projects/**"
-      - ".github/tmp/**"
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,36 +3,16 @@ name: CI • Unified Checks (Lint, Test, Validate)
 on:
   pull_request:
     branches: [develop]
-    paths:
-      - "agents/**"
-      - "skills/**"
-      - "hooks/**"
-      - "workflows/**"
-      - "instructions/**"
-      - "plugins/**"
-      - ".github/**"
-      - ".github/scripts/**"
-      - "cookbook/**"
-      - "package.json"
-      - "package-lock.json"
-      - ".nvmrc"
-      - "*.md"
+    paths-ignore:
+      - ".github/reports/**"
+      - ".github/projects/**"
+      - ".github/tmp/**"
   push:
     branches: [develop]
-    paths:
-      - "agents/**"
-      - "skills/**"
-      - "hooks/**"
-      - "workflows/**"
-      - "instructions/**"
-      - "plugins/**"
-      - ".github/**"
-      - ".github/scripts/**"
-      - "cookbook/**"
-      - "package.json"
-      - "package-lock.json"
-      - ".nvmrc"
-      - "*.md"
+    paths-ignore:
+      - ".github/reports/**"
+      - ".github/projects/**"
+      - ".github/tmp/**"
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
## Summary

Fixed GitHub Actions workflow validation error in checks.yml that was blocking all workflow runs.

**Issue:** Invalid workflow syntax — cannot define both `paths` and `paths-ignore` for the same trigger event.

**Solution:** Updated to use `paths-ignore` only for cleaner, more maintainable trigger configuration.

## Changes

- ✅ Removed conflicting `paths` lists from `pull_request` and `push` events
- ✅ Simplified to use `paths-ignore` only (excludes reports, projects, tmp)
- ✅ Workflow now has valid syntax and will execute on next trigger

## Testing

This fix enables checks.yml to:
- Execute on all file changes except .github/reports/**, .github/projects/**, .github/tmp/**
- Run full test suite (822+ tests) on Node v22.x
- Validate the Node.js 22 upgrade stability

## Related

- Fixes workflow validation errors blocking CI
- Part of: Node.js 22 Post-Merge Monitoring (Issue #1432)
- Day 1 Monitoring Task (Issue #1433)

🤖 Generated with Claude Code