### PR TITLE
fix(ci): use a block scalar so issue-remediation-bulk.yml parses

### DIFF
--- a/.github/workflows/issue-remediation-bulk.yml
+++ b/.github/workflows/issue-remediation-bulk.yml
@@ -106,7 +106,10 @@ jobs:
       - name: Assign milestones
         if: ${{ inputs.remediate_milestones == 'true' && steps.fetch.outputs.count > 0 }}
         shell: bash
-        run: set +e; node .github/scripts/workflows/assign-milestones-workflow.js; echo "Exit code: $?"
+        run: |
+          set +e
+          node .github/scripts/workflows/assign-milestones-workflow.js
+          echo "Exit code: $?"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUES_JSON: ${{ steps.fetch.outputs.issues }}


### PR DESCRIPTION
## Summary

`.github/workflows/issue-remediation-bulk.yml:109` was a single-line `run:` ending in `echo "Exit code: $?"`. A colon followed by a space inside an unquoted plain YAML scalar is a syntax error, so the whole workflow failed to load — it never ran, and policy checks could not evaluate it.

One line becomes a block scalar. No behaviour change.

```yaml
run: |
  set +e
  node .github/scripts/workflows/assign-milestones-workflow.js
  echo "Exit code: $?"
```

Verified with `yaml.safe_load`: parses OK. Split out of #1456 so that PR stays a single-concern change.

## Linked issues

- Relates to #1456 — the gitleaks updater client-id migration; this unblocks its workflow-parse check.

## Changelog

### Fixed

- **`issue-remediation-bulk.yml` failed to parse** — a single-line `run:` containing `Exit code: $?` was invalid YAML, so the workflow never loaded. Converted to a block scalar. ([PR #1491](https://github.com/lightspeedwp/.github/pull/1491))

### Checklist (Global DoD / PR)

- [x] Single-concern, minimal change
- [x] YAML validated with `yaml.safe_load`
- [x] No behaviour change to the workflow's commands
- [x] No secrets, credentials or tokens added
- [x] No permission, `runs-on` or trust-boundary changes
- [x] CHANGELOG entry included above
- [x] Linked issues recorded
