### PR TITLE
chore: exclude shell scripts from ESLint linting

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -48,6 +48,7 @@ const ignoreFolders = process.env.ESLINT_IGNORE
       "website/dist/**", // Migrated from .eslintignore
       "website/node_modules/**", // Migrated from .eslintignore
       "projects/active/**", // Project documentation and deliverables (excluded from linting)
+      "hooks/**", // Shell scripts and portable hooks (not JavaScript)
     ];
 
 /**


### PR DESCRIPTION
## Linked issues

Relates to #1489

## Context

Shell scripts in the `hooks/` directory are not JavaScript and should not be linted by ESLint. This prevents ESLint from attempting to process them and causing linting failures.

## Changes

- Add `hooks/**` to ESLint ignore patterns in eslint.config.cjs

## Impact

- Fixes linting failures on portable shell scripts (hooks/pr-checklist-validator.sh, hooks/pr-merge-governance-validator.sh, etc.)
- Unblocks PRs that add or modify shell scripts in hooks/

## Changelog

### Changed

- ESLint configuration now properly excludes shell scripts from linting

---

### Checklist (Global DoD / PR)

- [x] All AC met and demonstrated
- [x] Tests added/updated (N/A - config change)
- [x] Docs updated (if user-facing)
- [x] Code quality verified
- [x] CI passing

---