### PR TITLE
fix: Remove duplicate CHANGELOG entries from PR #1629 merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,12 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Safe Footer Injection frontmatter detection** — Extended YAML frontmatter detection to support variable-length headers by searching entire file instead of limited line count. Changed delimiter matching to exact match `trim() === '---'` to prevent false positives on YAML content lines. ([PR #1632](https://github.com/lightspeedwp/.github/pull/1632))
 
-- **Phase 3 label validation enforcement — Validation script & workflow** — Pre-creation label validation script (`validate-labels-before-creation.cjs`) enforces canonical label prefixes and one-hot constraint per family. GitHub Actions workflow validates on issue/PR creation, editing, labeling, and PR synchronization. Prevents bare labels (e.g., `bug`, `feature`, `urgent`) and enforces required prefixes (e.g., `type:bug`, `priority:critical`). ([PR #1613](https://github.com/lightspeedwp/.github/pull/1613), [#1612](https://github.com/lightspeedwp/.github/issues/1612))
-
-- **Phase 1 critical fixes — broken badges and release process** — Fixed 33 broken documentation badges (workflow status, build badges); fixed release workflow to default to `--dry-run` with explicit `--live` flag requirement; added authorization gating for release operations. ([PR #1609](https://github.com/lightspeedwp/.github/pull/1609), [#1547](https://github.com/lightspeedwp/.github/issues/1547), [#1548](https://github.com/lightspeedwp/.github/issues/1548), [#1549](https://github.com/lightspeedwp/.github/issues/1549))
-
-- **Address Copilot review feedback on PR #1591** — Fixed broken relative paths in audit report files and adjusted path resolution for portable asset locations. ([PR #1610](https://github.com/lightspeedwp/.github/pull/1610), [#1591](https://github.com/lightspeedwp/.github/issues/1591))
-
 - **Fix README frontmatter** — Corrected Phase 2B project README frontmatter. ([PR #1540](https://github.com/lightspeedwp/.github/pull/1540), [#1375](https://github.com/lightspeedwp/.github/issues/1375))
 
 - **Fix import error** — Fixed `_fetchCanonicalLabels` function reference. ([PR #1540](https://github.com/lightspeedwp/.github/pull/1540))
@@ -101,12 +95,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release Process V2 specification and OpenSpec analysis** — Defined Release Process V2 specification with comprehensive OpenSpec analysis for standardized release workflows and automation. ([PR #1545](https://github.com/lightspeedwp/.github/pull/1545))
 
 - **Gitleaks secret scanning** — Added `gitleaks-reusable.yml`, an organisation-wide reusable workflow other repositories call via `workflow_call`, plus a `gitleaks.yml` caller running on pull requests into `develop`/`main`. Runs the open-source Gitleaks CLI directly (the `gitleaks-action` wrapper requires a paid licence for organisation repositories). Per-PR runs scan the working tree; `workflow_dispatch` accepts a `full-history` input for on-demand full-history rescans. A baseline full-history scan of this repository returned 50 hits, all verified as placeholder values in documentation and tests, allowlisted in `.gitleaks.toml`. ([PR #1444](https://github.com/lightspeedwp/.github/pull/1444))
-
-- **Phase 1–3 completion documentation** — Comprehensive project completion report documenting Phase 1 restructuring, Phase 2 label remediation, and Phase 3 validation enforcement. Includes audit findings, 5-phase remediation timeline, and governance architecture. ([PR #1624](https://github.com/lightspeedwp/.github/pull/1624))
-
-- **Label creation governance in CLAUDE.md and AGENTS.md** — Added mandatory label prefix enforcement rules to organisation-wide governance documents. All labels must use canonical prefixes (type:, status:, priority:, area:, etc.) from `.github/labels.yml` (158 canonical labels). One-hot constraint per family except meta:, comp:, lang: which allow multiples. Prevents bare labels and enforces validation at issue/PR creation time. ([PR #1611](https://github.com/lightspeedwp/.github/pull/1611))
-
-- **Phase 4 label validation documentation** — Comprehensive documentation package: updated LABELING.md v1.1.0 with ~500 lines on validation rules and error guidance; new LABELING_FAQ.md (~2,500 lines) with 30+ FAQs organized by topic; new LABELING_EXAMPLES.md (~1,000 lines) with 20+ real-world label combinations for issues and PRs. ([PR #1613](https://github.com/lightspeedwp/.github/pull/1613), [docs/LABELING.md](./docs/LABELING.md), [docs/LABELING_FAQ.md](./docs/LABELING_FAQ.md), [docs/LABELING_EXAMPLES.md](./docs/LABELING_EXAMPLES.md))
 
 - **Add Gitleaks scanning** — Reusable workflows for PR secret scanning. ([PR #1444](https://github.com/lightspeedwp/.github/pull/1444))
 


### PR DESCRIPTION
## Summary

PR #1629 was merged after PR #1630, creating duplicate entries in the CHANGELOG. This fix removes 6 duplicate CHANGELOG entries while preserving the more complete versions from PR #1630.

## Root Cause

- PR #1630 merged with CHANGELOG entries for Phase 1-3 work
- PR #1629 targeted the same PRs with overlapping CHANGELOG content
- Merge conflict resolution kept both versions, creating duplicates

## Changes

Removed duplicate CHANGELOG entries:
- Phase 3 label validation enforcement (PR #1613)
- Phase 1 critical fixes (PR #1609)
- Address Copilot review feedback (PR #1610)
- Phase 1–3 completion documentation (PR #1624)
- Label creation governance (PR #1611)
- Phase 4 label validation documentation (PR #1613)

## Changelog

### Fixed

- **Remove duplicate CHANGELOG entries** — PR #1629 merge created duplicate entries for Phase 1-3 completion work. Removed 6 duplicate entries while preserving complete versions from PR #1630. ([PR #1630](https://github.com/lightspeedwp/.github/pull/1630), [PR #1629](https://github.com/lightspeedwp/.github/pull/1629))

## Linked Issues

Resolves merge conflict from #1629

### Checklist (Global DoD / PR)

- [x] All AC met and demonstrated
- [x] Documentation updated (CHANGELOG deduplicated)
- [x] Code reviewed and validated
- [x] CI green (linting passes)
- [x] No secrets/sensitive data introduced

---

Generated with [Claude Code](https://claude.com/claude-code)