### PR TITLE
ci: Configure Mergify for sequential PR processing

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,6 +1,10 @@
 queue_rules:
   - name: dependabot-develop
     merge_method: squash
+    batch_size: 1
+
+merge_queue:
+  max_parallel_checks: 1
 
 pull_request_rules:
   # Keep Dependabot PRs up-to-date by rebasing if develop has moved ahead
@@ -29,6 +33,12 @@ pull_request_rules:
         type: APPROVE
       queue:
         name: dependabot-develop
+        merge_conditions:
+          - author~=^(dependabot\[bot\]|app/dependabot)$
+          - base=develop
+          - label=area:dependencies
+          - -draft
+          - -conflict
 
   # Keep imgbot image optimizations up-to-date by rebasing if develop has moved ahead
   - name: Keep imgbot image optimizations current on develop


### PR DESCRIPTION
## Summary

Configure Mergify for sequential PR processing to resolve branch-protection conflict.

## Changes
- Add `batch_size: 1` to queue rules (sequential processing)
- Add `merge_queue: { max_parallel_checks: 1 }` (in-place checks)
- Add `merge_conditions` to Dependabot queue (safety checkpoint)

## Why
Resolves Mergify/branch-protection incompatibility. Sequential checks work with GitHub's "Require branches to be up to date before merging" rule via auto-rebase.

## Linked Issues
Resolves: Mergify queue blocked by branch-protection conflict (Option B implementation)

## Checklist (Global DoD / PR)
- [x] All AC met
- [x] No tests needed (config only)
- [x] CI green
- [x] Ready for merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)