### PR TITLE
fix: Resolve Mergify queue two-step CI configuration error

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -37,6 +37,7 @@ pull_request_rules:
           - author~=^(dependabot\[bot\]|app/dependabot)$
           - base=develop
           - label=area:dependencies
+          - check-success=All Checks Passed
           - -draft
           - -conflict
 


### PR DESCRIPTION
## Summary

Fix Mergify configuration to ensure merge_conditions match queue_conditions, resolving the 'Configuration not compatible with branch protection' error.

## Changes
- Add `check-success=All Checks Passed` to merge_conditions in Dependabot queue rule
- Ensures queue_conditions and merge_conditions are identical (one-step CI)

## Why
Mergify requires conditions to match to avoid two-step CI when branch-protection 'Require branches to be up to date' is enabled. This allows sequential PR processing to work correctly.

## Testing
Both PRs #1656 and #1658 should now queue and merge sequentially without Mergify errors.

## Checklist (Global DoD / PR)
- [x] All AC met
- [x] No tests needed (config-only fix)
- [x] CI green
- [x] Ready for merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)