### PR TITLE
fix: Update footer validation script paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "validate:frontmatter:changed": "node scripts/validation/validate-frontmatter-freshness.js",
     "validate:branch-name": "node scripts/validation/validate-branch-name.js",
     "validate:workflows": "node scripts/validation/validate-workflows.js",
-    "validate:footers": "sh -c 'node .github/scripts/validate-footers.js \"$@\" && node .github/scripts/validate-footer-cleanup.js \"$@\"' --",
+    "validate:footers": "sh -c 'node scripts/validate-footer-injection.js \"$@\" && node scripts/validate-footer-cleanup.js \"$@\"' --",
     "validate:labeling-configs": "node scripts/validation/validate-labeling-configs.cjs",
     "validate:retired-doc-links": "node scripts/validation/validate-retired-doc-links.cjs",
     "validate:issue-fields": "node scripts/validation/validate-issue-fields.cjs",


### PR DESCRIPTION
## Summary

Updated footer validation script paths in package.json to reference the correct location after Phase 2B script reorganization.

- Changed `node .github/scripts/validate-footers.js` → `node scripts/validate-footer-injection.js`
- Changed `node .github/scripts/validate-footer-cleanup.js` → `node scripts/validate-footer-cleanup.js`

Scripts were moved to root `scripts/` directory as part of Phase 2B portable script organization, but package.json was not updated. This caused CI validation errors whenever `npm run validate:footers` was called.

## Linked issues

Fixes CI validation errors from Phase 2B script reorganization (no explicit issue, but aligns with Phase 2B completion).

## Test plan

- [x] Verified scripts exist at new paths
- [x] Tested `npm run validate:footers` with updated paths  
- [x] Confirmed validation workflow succeeds

## Global DoD checklist

- [x] Code follows project standards (one-line fix to package.json)
- [x] No breaking changes (script paths corrected, same functionality)
- [x] Tested locally (validated script paths work)
- [x] Documentation updated if applicable (N/A - simple path fix)
- [x] No security or performance concerns

🤖 Generated with Claude Code