### PR TITLE
fix: Remove invalid Mergify queue configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -33,13 +33,6 @@ pull_request_rules:
         type: APPROVE
       queue:
         name: dependabot-develop
-        merge_conditions:
-          - author~=^(dependabot\[bot\]|app/dependabot)$
-          - base=develop
-          - label=area:dependencies
-          - check-success=All Checks Passed
-          - -draft
-          - -conflict
 
   # Keep imgbot image optimizations up-to-date by rebasing if develop has moved ahead
   - name: Keep imgbot image optimizations current on develop


### PR DESCRIPTION
Removes invalid `merge_conditions` field from Mergify queue action. This field is not supported by Mergify and was causing configuration validation errors that blocked PR merging.

The queue conditions should be defined in the `queue_rules` section, not in the queue action itself.