### PR TITLE
fix: exempt dependabot PRs from branch name validation

### DIFF
--- a/.github/workflows/branch-name-validation.yml
+++ b/.github/workflows/branch-name-validation.yml
@@ -36,11 +36,19 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
           TARGET_BRANCH: ${{ github.base_ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           # Check exemptions: release/* and hotfix/* are allowed on main
           if [[ "$TARGET_BRANCH" == "main" ]] && [[ "$BRANCH_NAME" =~ ^(release|hotfix)/ ]]; then
             echo "valid=true" >> $GITHUB_OUTPUT
             echo "message=Branch is exempt (release or hotfix on main)"
+            exit 0
+          fi
+
+          # Exempt dependabot and renovate PRs from branch name validation
+          if [[ "$PR_AUTHOR" == "dependabot[bot]" ]] || [[ "$PR_AUTHOR" == "renovate[bot]" ]] || [[ "$BRANCH_NAME" =~ ^(dependabot|renovate)/ ]]; then
+            echo "valid=true" >> $GITHUB_OUTPUT
+            echo "message=Branch is exempt (automated bot)"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

Adds exemption for dependabot and renovate PRs from branch name validation checks.

- Exempts  and  PR authors
- Skips validation for branches matching  and  patterns
- Allows automated dependency update PRs to merge without branch naming conflicts

## Resolves

- Fixes PR #1864: build(deps): bump linkify-it and markdownlint
- Fixes PR #1870: build(deps): bump markdown-it, markdownlint and markdownlint-cli2

## Why

GitHub's dependabot creates branches with names like `dependabot/npm_and_yarn/multi-{hash}` which don't follow the LightSpeed branching strategy (`{type}/{scope}-{title}`). Since we cannot control dependabot's branch naming, we need to exempt it from validation to allow these critical dependency updates to merge automatically.