### PR TITLE
fix: correct PR template reference path in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,7 +357,7 @@ Templates located in `.github/ISSUE_TEMPLATE/`:
 - **System Summary:** [docs/AI_FEEDBACK_SYSTEM_SUMMARY.md](./docs/AI_FEEDBACK_SYSTEM_SUMMARY.md) — Complete system overview
 - **Full Guide:** [docs/ai-feedback-response-tracking.md](./docs/ai-feedback-response-tracking.md) — Comprehensive guide with examples
 - **Workflow Details:** [docs/WORKFLOW_AI_FEEDBACK_VALIDATION.md](./docs/WORKFLOW_AI_FEEDBACK_VALIDATION.md) — Technical configuration and automation
-- **Template:** [PULL_REQUEST_TEMPLATE/FEEDBACK_RESPONSE.md](./PULL_REQUEST_TEMPLATE/FEEDBACK_RESPONSE.md) — Template to copy
+- **Template:** [.github/PULL_REQUEST_TEMPLATE/FEEDBACK_RESPONSE.md](./.github/PULL_REQUEST_TEMPLATE/FEEDBACK_RESPONSE.md) — Template to copy
 - **Examples:** [examples/FEEDBACK_RESPONSE_example-simple.md](./examples/FEEDBACK_RESPONSE_example-simple.md) and [examples/FEEDBACK_RESPONSE_example-complex.md](./examples/FEEDBACK_RESPONSE_example-complex.md)
 
 **What This Enables:**


### PR DESCRIPTION
## Summary

Fixed incorrect reference path in CLAUDE.md for the AI Feedback Response template.

The `FEEDBACK_RESPONSE.md` template is stored in `.github/PULL_REQUEST_TEMPLATE/` but was incorrectly referenced in CLAUDE.md as `PULL_REQUEST_TEMPLATE/` (missing the `.github/` prefix).

This violates the repository structure rules documented in CLAUDE.md under **Repository Boundaries**, which clearly state:
> GitHub-native governance files (templates, labels, workflows) must go in `.github/`, not at the root level

## Changes

**File:** CLAUDE.md (line 360)

- **Before:** `[PULL_REQUEST_TEMPLATE/FEEDBACK_RESPONSE.md](./PULL_REQUEST_TEMPLATE/FEEDBACK_RESPONSE.md)`
- **After:** `[.github/PULL_REQUEST_TEMPLATE/FEEDBACK_RESPONSE.md](./.github/PULL_REQUEST_TEMPLATE/FEEDBACK_RESPONSE.md)`

## Verification

✅ Template file already exists at correct location: `.github/PULL_REQUEST_TEMPLATE/FEEDBACK_RESPONSE.md`
✅ Reference now matches actual file location
✅ Complies with repository structure rules
✅ Example files remain in root `examples/` (reusable assets per CLAUDE.md)

## Related Documentation

- **CLAUDE.md § Repository Boundaries** — Authority on file placement
- **Affected Section:** "AI Feedback PR Review Validation" (line 330)

## Linked Issues

Resolves #2003 (PR Template Reference Path Structure Violation)

## Changelog

- Fixed incorrect `.github/` prefix in CLAUDE.md reference for PR template

## Global DoD Checklist

- [x] Code changes are minimal and focused
- [x] Repository structure complies with CLAUDE.md rules
- [x] References updated to match actual file paths
- [x] All related issues are linked
- [x] Ready for merge
## Current Status
- **CI Status**: ✅ All checks passing (0/65)
- **Latest Commit**: `a2c7469` - fix: correct PR template reference path in CLAUDE.md
