### PR TITLE
fix: Remove unused 'path' imports from metrics scripts

### DIFF
--- a/scripts/workflows/metrics/__tests__/generate-metrics-report.test.js
+++ b/scripts/workflows/metrics/__tests__/generate-metrics-report.test.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const path = require('path');
 const MetricsReportGenerator = require('../generate-metrics-report');
 
 jest.mock('fs');

--- a/scripts/workflows/metrics/create-metrics-issues.js
+++ b/scripts/workflows/metrics/create-metrics-issues.js
@@ -12,7 +12,6 @@
  */
 
 const fs = require('fs');
-const path = require('path');
 
 class MetricsIssuesCreator {
   constructor(options = {}) {


### PR DESCRIPTION
## Summary

Code quality improvements for Metrics Agent Task 2.4 scripts by removing unused imports.

## Linked Issues

Related: #2054 (Metrics Agent Phase 2 - Task 2.4)

## Changes

- Remove unused `path` import from generate-metrics-report.test.js
- Remove unused `path` import from create-metrics-issues.js

## Changelog

- fix: Remove unused imports from metrics scripts

## Global DoD Checklist

- [x] Code changes follow repository standards
- [x] Code quality checks pass (CodeQL)
- [x] Branch naming follows conventions
- [x] All tests passing

---

🤖 Generated with Claude Code