### PR TITLE
fix: Correct percentile test assertion to match function return type

### DIFF
--- a/scripts/metrics/__tests__/metrics-agent.test.js
+++ b/scripts/metrics/__tests__/metrics-agent.test.js
@@ -541,7 +541,7 @@ describe("MetricsCollector", () => {
 
     test("handles empty array", () => {
       const result = collector.percentile([], 0.5);
-      expect(result).toBe(0);
+      expect(parseFloat(result)).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Linked issues

Fixes #2164

## Context

- Severity/Impact: Medium
- Affected versions/environments: Test suite for MetricsCollector

## Root Cause

The `percentile()` function returns formatted strings with two decimal places (e.g., `"0.00"`), but the test assertion expected a raw number value (`0`). The other percentile tests correctly use `parseFloat()` to handle the string return value.

## Fix Summary

Updated the failing test assertion to use `parseFloat()` consistent with the other percentile tests:
- Changed `expect(result).toBe(0)` to `expect(parseFloat(result)).toBe(0)`
- Aligns test with actual function behavior and the testing pattern established in the suite

## Verification

- [x] All 100 Metrics Agent tests now pass
- [x] Assertion type matches function return type
- [x] Consistent with other percentile test assertions

## Risk & Rollback

- Risk level: Very Low
- Rollback plan: Revert commit

## Changelog

- Corrected percentile test assertion in MetricsCollector test suite to properly handle string return values

---

### Checklist (Global DoD / PR)

- [x] All AC met and demonstrated
- [x] Tests added/updated (test-only fix)
- [x] Accessibility checklist completed (where relevant):
  - [x] N/A - Test-only changes
- [x] Docs/readme/changelog updated (if user-facing)
- [x] Security checklist completed (where relevant):
  - [x] N/A - Test-only changes
- [x] Code/design reviews approved
- [x] CI green; linked issues closed; release notes prepared (if shipping)