### PR TITLE
fix: Resolve CI validator failures (#1961, #1966)

### DIFF
--- a/scripts/automation/handlers/handle-pr-merged.js
+++ b/scripts/automation/handlers/handle-pr-merged.js
@@ -311,6 +311,29 @@ module.exports = {
 };
 
 /**
+ * Extract linked issue number from PR body
+ * @param {string} prBody - PR body content
+ * @returns {number|null} Issue number or null
+ */
+function extractLinkedIssue(prBody) {
+  if (!prBody) return null;
+
+  const patterns = [
+    /(?:Resolves|Fixes|closes?|fix|resolve|related)\s+#(\d+)/i,
+    /#(\d+)/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = prBody.match(pattern);
+    if (match) {
+      return parseInt(match[1], 10);
+    }
+  }
+
+  return null;
+}
+
+/**
  * Generate completion report for issue
  * @param {number} issueNumber - Issue number
  * @returns {object} Completion report

--- a/scripts/validation/validate-frontmatter-changed.js
+++ b/scripts/validation/validate-frontmatter-changed.js
@@ -108,9 +108,10 @@ function validateFrontmatter(files) {
   return !hasErrors;
 }
 
-// Main execution
-const baseSha = process.argv[2] || process.env.BASE_SHA || "HEAD~1";
-const headSha = process.argv[3] || process.env.HEAD_SHA || "HEAD";
+// Main execution - parse --base and --head flags
+const args = require("minimist")(process.argv.slice(2));
+const baseSha = args.base || process.env.BASE_SHA || "HEAD~1";
+const headSha = args.head || process.env.HEAD_SHA || "HEAD";
 
 const changedFiles = getChangedFiles(baseSha, headSha);
 


### PR DESCRIPTION
## Linked issues

Closes #1961
Closes #1966

## Summary

Fixes two critical CI validator failures that were blocking all PRs from merging:

1. **ESLint error** (issue #1961): Missing `extractLinkedIssue` function in `handle-pr-merged.js` was causing linting job to fail with 2 ESLint errors
2. **Frontmatter validator** (issue #1966): Validator was not properly parsing `--base` and `--head` CLI flags passed by CI workflow

## Changes

- Added missing `extractLinkedIssue` function to `scripts/automation/handlers/handle-pr-merged.js`
  - Extracts linked issue number from PR body using pattern matching
  - Matches "Resolves #123", "Fixes #123", "Related: #456", etc.

- Fixed `scripts/validation/validate-frontmatter-changed.js` flag parsing
  - Updated to use minimist for proper CLI argument parsing
  - Now correctly handles `--base` and `--head` flags from CI workflow

## Impact / Compatibility

- Runtime/behaviour changes: None (fixes validator functionality)
- Build/dev-experience impact: CI validators now pass on all PRs with valid content

## Verification

- [x] ESLint errors resolved (0 errors, 119 warnings only)
- [x] All linting checks pass (`npm run lint:all`)
- [x] Frontmatter validator works with --base and --head flags
- [x] All validation scripts pass locally

## Risk & Rollback

- Risk level: Low (fixes broken validators)
- Rollback plan: Revert commit

## Changelog

### Fixed

- Fixed ESLint error in `handle-pr-merged.js` by adding missing `extractLinkedIssue` function
- Fixed frontmatter validator to properly parse `--base` and `--head` CLI flags from CI workflow

---

### Checklist (Global DoD / PR)

- [x] All AC met and demonstrated (both validators fixed and tested)
- [x] No tests needed (validator functionality fixes)
- [x] No accessibility or security impacts
- [x] No docs updates needed (internal validator fixes)
- [x] CI validators pass