### PR TITLE
refactor(validation): P1.1 - Unify branch name validators

### DIFF
--- a/.github/workflows/branch-name-validation.yml
+++ b/.github/workflows/branch-name-validation.yml
@@ -57,8 +57,8 @@ jobs:
             exit 0
           fi
 
-          # Run validation script
-          if node scripts/validation/validate-branch-name.js "$BRANCH_NAME" 2>&1 | tee validation-output.txt; then
+          # Run validation script (using strict .cjs validator)
+          if node scripts/validation/validate-branch-name.cjs "$BRANCH_NAME" 2>&1 | tee validation-output.txt; then
             echo "valid=true" >> $GITHUB_OUTPUT
           else
             echo "valid=false" >> $GITHUB_OUTPUT

--- a/scripts/validation/__tests__/validate-branch-name.test.js
+++ b/scripts/validation/__tests__/validate-branch-name.test.js
@@ -24,7 +24,7 @@ describe("validate-branch-name", () => {
         "feat/add-login-page",
         "fix/header-alignment",
         "hotfix/critical-security-patch",
-        "release/v1.2.0",
+        "release/v1-2-0",
         "refactor/extract-utils",
         "chore/update-deps",
         "docs/readme-overhaul",
@@ -71,9 +71,14 @@ describe("validate-branch-name", () => {
       expect(isAllowed("chore/update_deps-2025")).toBe(false);
     });
 
-    it("accepts version-style slugs with dots", () => {
-      expect(isAllowed("fix/v2.1.0-patch")).toBe(true);
-      expect(isAllowed("release/v1.6.0")).toBe(true);
+    it("accepts version-style slugs with hyphens (kebab-case)", () => {
+      expect(isAllowed("fix/v2-1-0-patch")).toBe(true);
+      expect(isAllowed("release/v1-6-0")).toBe(true);
+    });
+
+    it("rejects version-style slugs with dots (not allowed)", () => {
+      expect(isAllowed("fix/v2.1.0-patch")).toBe(false);
+      expect(isAllowed("release/v1.6.0")).toBe(false);
     });
 
     it("rejects the forbidden claude/ prefix", () => {
@@ -113,7 +118,7 @@ describe("validate-branch-name", () => {
     });
 
     it("allows release/* branches to target main", () => {
-      const result = checkBaseBranch("release/v1.5.0", "main");
+      const result = checkBaseBranch("release/v1-5-0", "main");
 
       expect(result.valid).toBe(true);
     });

--- a/scripts/validation/validate-branch-name.js
+++ b/scripts/validation/validate-branch-name.js
@@ -50,7 +50,7 @@ const BOT_PREFIXES = /^(dependabot|renovate)\//;
 const AUDIT_BRANCH_PATTERN = /^pr-\d+-audit$/;
 const PROTECTED_BRANCHES = new Set(["main", "develop"]);
 const BRANCH_PATTERN = new RegExp(
-  `^(${ALLOWED_PREFIXES.join("|")})/[a-z0-9.-]+$`,
+  `^(${ALLOWED_PREFIXES.join("|")})/([a-z0-9]+(?:-[a-z0-9]+)*)-([a-z0-9]+(?:-[a-z0-9]+)*)$`,
 );
 
 function getArgValue(flag) {
@@ -189,7 +189,7 @@ function checkBranchReuse(branchName) {
 function printFailure(branchName) {
   console.error(`Branch '${branchName}' does not follow the required format.`);
   console.error(
-    "Expected: {prefix}/{branch-slug} (see docs/BRANCHING_STRATEGY.md)",
+    "Expected: {type}/{scope}-{short-title} (see docs/BRANCHING_STRATEGY.md)",
   );
   console.error(`Allowed prefixes: ${ALLOWED_PREFIXES.join(", ")}`);
   console.error("Audit replay branches: pr-<number>-audit");


### PR DESCRIPTION
## Linked issues

Relates to #1967 (CI Validation Issues: Branch Naming & Gitleaks Discrepancies)
Relates to #1755 (Branch Naming Enforcement Workflow)

## Summary

Unified the branch name validation scripts to enforce identical strict pattern across all validation layers. This eliminates the divergence between `.cjs` (strict) and `.js` (permissive) validators that was causing inconsistent branch naming enforcement.

**Problem Addressed:**
- `.cjs` validator enforced strict `{type}/{scope}-{title}` pattern
- `.js` validator allowed permissive `{type}/{anything}` pattern with dots
- Workflow used `.js` (permissive), allowing invalid branches to pass validation
- Test matrix from Phase 2 showed divergence: `release/v1.0.0` failed .cjs but passed .js

## Safety Nets

- Existing tests covering behaviour: 38 tests in `scripts/validation/__tests__/validate-branch-name.test.js`
- New/refined tests added: Updated tests for strict pattern (no dots allowed)
- Static analysis/lint rules touched: Validation regex pattern unified

## Approach

- **Structural changes (APIs, patterns):**
  - Updated `.js` validator regex from `^(${ALLOWED_PREFIXES.join("|")})/[a-z0-9.-]+$` to strict `^(${ALLOWED_PREFIXES.join("|")})/([a-z0-9]+(?:-[a-z0-9]+)*)-([a-z0-9]+(?:-[a-z0-9]+)*)$`
  - Updated workflow to use `.cjs` instead of `.js` (strict validator is canonical)
  - Updated error messages to reference correct pattern format

- **Dead code removed:** No (both validators remain; `.js` may be used elsewhere)

## Testing

**Unit Tests:** ✅ All 38 tests pass
```
Test Suites: 1 passed, 1 total
Tests:       38 passed, 38 total
```

**Validation Test Matrix:**

| Branch | .cjs | .js | Result |
|--------|------|-----|--------|
| `release/v1.0.0` | ✗ | ✗ | Now unified (dots rejected) |
| `chore/release` | ✗ | ✗ | Now unified (missing separator) |
| `feat/-dash-start` | ✗ | ✗ | Now unified (invalid format) |
| `feat/my-feature-with-long-name` | ✓ | ✓ | Consistent ✓ |
| `claude/my-feature` | ✗ | ✗ | Consistent ✓ |
| `release/v1-0-0` | ✓ | ✓ | Now accepted (hyphens) |

## Verification

- [x] Unit tests pass locally (38/38)
- [x] Both validators tested with Phase 2 test matrix
- [x] Workflow updated to use strict validator
- [x] Error messages clarified

## Risk & Rollback

- **Risk level:** Low
  - No user-facing changes; internal validation improvement
  - Stricter pattern may reject previously-created branches with dots in version numbers
  - Validators now reject `release/v1.0.0`; must use `release/v1-0-0`

- **Rollback plan:** Revert commit (single commit; clean history)

## Changelog

### Changed

- Unified branch name validation pattern across `.cjs` and `.js` validators to enforce strict `{type}/{scope}-{title}` format
- Updated GitHub Actions workflow to use `.cjs` (strict) validator instead of `.js` (permissive)
- Updated validator tests to reflect strict kebab-case requirement (no dots, no underscores)
- Clarified error messages to reference correct pattern: `{type}/{scope}-{short-title}`

### Fixed

- Resolved validator divergence: both now reject permissive patterns like `release/v1.0.0`, `chore/release`, `feat/-dash-start`

---

### Checklist (Global DoD / PR)

- [x] All AC met and demonstrated
- [x] Tests added/updated (38 tests all passing)
- [x] No accessibility/security implications (validation only)
- [x] Docs updated: test changes clarify strict pattern requirement
- [x] Code review ready (self-review complete)
- [x] CI green; related to branch-naming-validation audit project

---

**Phase:** P1.1 of 6-phase remediation plan

---
_Generated by [Claude Code](https://claude.ai/code/session_011NVnti4DjcBkz59RmSWZKh)_