### PR TITLE
fix(workflows): close pull_request_target fork-checkout hole; bump actions to latest

### DIFF
--- a/.github/workflows/actions-minute-savings-watch.yml
+++ b/.github/workflows/actions-minute-savings-watch.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Generate before/after savings report
         id: report
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           INPUT_CUTOFF: ${{ github.event.inputs.cutoff_iso || '2026-07-21T00:00:00Z' }}
           INPUT_MIN_POST_RUNS: ${{ github.event.inputs.min_post_runs || '40' }}
@@ -207,7 +207,7 @@ jobs:
             core.summary.addRaw(markdown).write();
 
       - name: Upload savings report artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: actions-minute-savings-report
           path: |
@@ -216,7 +216,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish savings report to tracking issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('node:fs');

--- a/.github/workflows/allocate-pr-issue-to-milestone.yml
+++ b/.github/workflows/allocate-pr-issue-to-milestone.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".nvmrc"
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Post comment on PR
         if: steps.target.outputs.type == 'pr' && success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = ${{ steps.target.outputs.pr_number }};
@@ -112,7 +112,7 @@ jobs:
 
       - name: Post comment on issue
         if: steps.target.outputs.type == 'issue' && success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issueNumber = ${{ steps.target.outputs.issue_number }};

--- a/.github/workflows/badges-verification.yml
+++ b/.github/workflows/badges-verification.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: "Setup Node.js"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/branch-name-validation.yml
+++ b/.github/workflows/branch-name-validation.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -79,7 +79,7 @@ jobs:
 
       - name: Post validation result
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/changelog-management.yml
+++ b/.github/workflows/changelog-management.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Require changelog update or skip label
         id: gate
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const cp = require("node:child_process");
@@ -137,7 +137,7 @@ jobs:
 
       - name: Check if CHANGELOG.md was modified
         id: check_changelog
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,9 +15,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
       - name: Validate changelog schema

--- a/.github/workflows/checklist-finalisation.yml
+++ b/.github/workflows/checklist-finalisation.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Finalise issue checklist sections
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- checklist-finalisation -->';
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Finalise PR checklist sections
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- checklist-finalisation -->';

--- a/.github/workflows/docs-maintenance.yml
+++ b/.github/workflows/docs-maintenance.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-update-report
           path: .github/reports/mermaid-audit/update-report.md
@@ -251,7 +251,7 @@ jobs:
 
       - name: Upload audit artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-audit-report-${{ github.run_number }}
           path: .github/reports/mermaid-audit/
@@ -259,7 +259,7 @@ jobs:
 
       - name: Create issue for critical findings
         if: failure() && github.event_name == 'schedule'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.create({

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Post PR comment with results
         if: github.event_name == 'pull_request' && steps.has_diagrams.outputs.result == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const syntaxOk    = '${{ steps.results.outputs.syntax_ok }}'   === 'true';
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload validation reports
         if: always() && steps.has_diagrams.outputs.result == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mermaid-validation-reports-${{ github.run_number }}
           path: |
@@ -253,7 +253,7 @@ jobs:
 
       - name: Post PR comment with README validation results
         if: github.event_name == 'pull_request' && steps.readme.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const frontmatterOk = '${{ steps.frontmatter.outcome }}' === 'success';

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload audit artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: documentation-audit-report-${{ github.run_number }}
           path: .github/reports/mermaid-audit/
@@ -150,7 +150,7 @@ jobs:
 
       - name: Create issue for critical findings
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.create({
@@ -226,7 +226,7 @@ jobs:
 
       - name: Upload regeneration artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: documentation-regeneration-${{ github.run_number }}
           path: .github/reports/
@@ -347,7 +347,7 @@ jobs:
 
       - name: Upload maintenance report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: documentation-maintenance-report-${{ github.run_number }}
           path: .github/reports/mermaid-audit/

--- a/.github/workflows/issue-create-enhanced.yml
+++ b/.github/workflows/issue-create-enhanced.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Create issue from template
         id: create
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -240,7 +240,7 @@ jobs:
       - name: Auto-assign milestone (if not provided)
         id: assign_milestone
         if: success() && !inputs.milestone
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { MilestoneAssignmentAgent } = require('./scripts/agents/includes/milestone-assignment.js');
@@ -273,7 +273,7 @@ jobs:
 
       - name: Post remediation checklist (if template gaps exist)
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { RemediationChecklistGenerator } = require('./scripts/agents/includes/remediation-checklist-generator.js');

--- a/.github/workflows/issue-create-from-template.yml
+++ b/.github/workflows/issue-create-from-template.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Create issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/issue-health-audit.yml
+++ b/.github/workflows/issue-health-audit.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Run issue health audit
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           REOPEN_INCOMPLETE: ${{ github.event.inputs.reopen_incomplete || 'true' }}

--- a/.github/workflows/issue-labeling-automation.yml
+++ b/.github/workflows/issue-labeling-automation.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Fetch issues to label
         id: fetch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const filter = '${{ inputs.issue_filter || "created >= 7 days ago" }}';
@@ -109,7 +109,7 @@ jobs:
 
       - name: Generate labeling report
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/issue-project-field-sync.yml
+++ b/.github/workflows/issue-project-field-sync.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Sync issues to project and fill fields
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           # Use a PAT with `project` scope if available; fall back to GITHUB_TOKEN.
           # GITHUB_TOKEN works for repo-linked projects when projects: write is set.

--- a/.github/workflows/issue-remediation-automation.yml
+++ b/.github/workflows/issue-remediation-automation.yml
@@ -111,7 +111,7 @@ jobs:
           always() &&
           github.event_name == 'schedule' &&
           !github.event.inputs.dry_run
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload remediation logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: remediation-reports-${{ github.run_id }}
           path: reports/
@@ -164,7 +164,7 @@ jobs:
 
       - name: Notify on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/issue-remediation-bulk.yml
+++ b/.github/workflows/issue-remediation-bulk.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Fetch non-compliant issues
         id: fetch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           DAYS: ${{ inputs.days }}
         with:
@@ -118,7 +118,7 @@ jobs:
 
       - name: Add missing type labels
         if: ${{ inputs.remediate_labels == 'true' && steps.fetch.outputs.count > 0 }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issues = JSON.parse('${{ steps.fetch.outputs.issues }}');
@@ -171,7 +171,7 @@ jobs:
 
       - name: Post remediation checklists
         if: ${{ inputs.remediate_templates == 'true' && steps.fetch.outputs.count > 0 }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { RemediationChecklistGenerator } = require('./scripts/agents/includes/remediation-checklist-generator.js');
@@ -197,7 +197,7 @@ jobs:
 
       - name: Run labeling workflow
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             core.info('Triggering unified labeling workflow...');
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: remediation-reports-${{ github.run_id }}
           path: |
@@ -230,7 +230,7 @@ jobs:
 
       - name: Summary
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const dryRun = '${{ inputs.dry_run }}' === 'true';

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -14,10 +14,10 @@ jobs:
   issues-agent:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 

--- a/.github/workflows/labeling-governance.yml
+++ b/.github/workflows/labeling-governance.yml
@@ -94,7 +94,7 @@ jobs:
           node scripts/agents/includes/report-writer.js > .github/reports/labeling/${{ github.run_id }}.md
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: labeling-report-${{ github.run_id }}
           path: |
@@ -126,7 +126,7 @@ jobs:
 
     steps:
       - name: Detect security-related Dependabot updates
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -195,7 +195,7 @@ jobs:
 
     steps:
       - name: Remove status:needs-triage label if present
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -54,13 +54,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: develop
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 
@@ -85,7 +85,7 @@ jobs:
       # Apply file/branch-based labels using labeler.yml (for PRs)
       - name: File/branch labeler (actions/labeler)
         if: github.event_name == 'pull_request'
-        uses: actions/labeler@v5
+        uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: ${{ env.LABELER_RULES }}
@@ -105,7 +105,7 @@ jobs:
           node scripts/agents/includes/report-writer.js > .github/reports/labeling/${{ github.run_id }}.md
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: labeling-report-${{ github.run_id }}
           path: .github/reports/labeling/${{ github.run_id }}.md

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,8 +8,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
       - run: npm ci

--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -18,10 +18,10 @@ jobs:
     name: validate-release-branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: ".nvmrc"
       - name: Validate release branch name

--- a/.github/workflows/manage-blocking-status-labels.yml
+++ b/.github/workflows/manage-blocking-status-labels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update blocking status labels for open issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Fetch all open issues

--- a/.github/workflows/meta-agent-validation.yml
+++ b/.github/workflows/meta-agent-validation.yml
@@ -28,12 +28,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "npm"
@@ -66,12 +66,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "npm"
@@ -81,7 +81,7 @@ jobs:
 
       - name: Get changed Markdown files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             **/*.md
@@ -121,7 +121,7 @@ jobs:
 
       - name: Report validation results
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({
@@ -159,7 +159,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -30,10 +30,10 @@ jobs:
   front-matter-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 
@@ -59,10 +59,10 @@ jobs:
   lint-and-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 
@@ -101,10 +101,10 @@ jobs:
     needs: [front-matter-validate, lint-and-links]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 
@@ -127,13 +127,13 @@ jobs:
     if: ${{ (success() || failure()) && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           fetch-depth: 2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 

--- a/.github/workflows/metadata-governance.yml
+++ b/.github/workflows/metadata-governance.yml
@@ -23,10 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
+        # Deliberately no `repository:`/`ref:` override: pull_request_target runs
+        # with a privileged token, so this must only ever execute trusted code
+        # from the base repository's default branch — never a fork's head ref.
+        # See: https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
         uses: actions/checkout@v7
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
           fetch-depth: 0
           clean: true
 

--- a/.github/workflows/metrics-collection.yml
+++ b/.github/workflows/metrics-collection.yml
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: npm
@@ -121,10 +121,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/metrics-pipeline.yml
+++ b/.github/workflows/metrics-pipeline.yml
@@ -63,21 +63,21 @@ jobs:
         run: npm run metrics:ci
 
       - name: Upload JSON artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontmatter-metrics-json
           path: metrics/out/frontmatter-metrics.json
           if-no-files-found: warn
 
       - name: Upload Markdown report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontmatter-metrics-md
           path: metrics/out/frontmatter-metrics.md
           if-no-files-found: error
 
       - name: Create or update tracking issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -150,7 +150,7 @@ jobs:
           node scripts/workflows/metrics/generate-report.cjs
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: weekly-metrics-report-${{ github.run_id }}
           path: |
@@ -202,7 +202,7 @@ jobs:
 
       - name: Post to discussions
         if: steps.read_report.outputs.content != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/metrics-reporting.yml
+++ b/.github/workflows/metrics-reporting.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: npm
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: metrics-report
           path: .github/reports/metrics/report-*.md
@@ -134,10 +134,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (develop)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: develop
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 
@@ -31,21 +31,21 @@ jobs:
         run: npm run metrics:ci
 
       - name: Upload JSON artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontmatter-metrics-json
           path: metrics/out/frontmatter-metrics.json
           if-no-files-found: warn
 
       - name: Upload Markdown report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontmatter-metrics-md
           path: metrics/out/frontmatter-metrics.md
           if-no-files-found: error
 
       - name: Create or update tracking issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/openspec-progress-phase.yml
+++ b/.github/workflows/openspec-progress-phase.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/openspec-report-progression.yml
+++ b/.github/workflows/openspec-report-progression.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"
@@ -61,7 +61,7 @@ jobs:
 
       - name: Archive reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: openspec-progression-reports
           path: |

--- a/.github/workflows/openspec-sync-labels.yml
+++ b/.github/workflows/openspec-sync-labels.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/openspec-validate-labels.yml
+++ b/.github/workflows/openspec-validate-labels.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/planner.yml
+++ b/.github/workflows/planner.yml
@@ -18,10 +18,10 @@ jobs:
     # See: .github/reports/audits/agent-infrastructure-audit-2025-12-10.md
     if: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 

--- a/.github/workflows/pr-template-validation.yml
+++ b/.github/workflows/pr-template-validation.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check PR Template
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/.github/workflows/project-archival.yml
+++ b/.github/workflows/project-archival.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload archival report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: project-archival-report-${{ github.run_id }}
           path: |

--- a/.github/workflows/project-maintenance-nightly.yml
+++ b/.github/workflows/project-maintenance-nightly.yml
@@ -18,8 +18,8 @@ jobs:
       has_gaps: ${{ steps.audit.outputs.has_gaps }}
       gap_count: ${{ steps.audit.outputs.gap_count }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "18"
           cache: "npm"
@@ -60,7 +60,7 @@ jobs:
           echo "### Project Maintenance Audit — $(date -u +'%Y-%m-%d %H:%M:%SZ') UTC"
           echo "${{ steps.audit.outputs.results }}" | jq '.'
       - if: failure() && steps.audit.outputs.gap_count >= 5
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/project-maintenance-on-demand.yml
+++ b/.github/workflows/project-maintenance-on-demand.yml
@@ -48,8 +48,8 @@ jobs:
     if: needs.validate-inputs.outputs.operation == 'audit'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "18"
           cache: "npm"
@@ -61,8 +61,8 @@ jobs:
     if: needs.validate-inputs.outputs.operation == 'create-docs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "18"
           cache: "npm"
@@ -87,7 +87,7 @@ jobs:
     if: needs.validate-inputs.outputs.operation == 'validate'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run validate mode
         env:
           PROJECTS: ${{ needs.validate-inputs.outputs.projects }}

--- a/.github/workflows/project-meta-sync.yml
+++ b/.github/workflows/project-meta-sync.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Create GitHub App installation token
         id: app-token
         if: steps.preflight.outputs.enabled == 'true'
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.LS_APP_ID }}
           private-key: ${{ secrets.LS_APP_PRIVATE_KEY }}
@@ -65,7 +65,7 @@ jobs:
       - name: Add item to project (new issues/PRs)
         id: addp
         if: steps.preflight.outputs.enabled == 'true'
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@v2.0.0
         with:
           project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-e2e-tests.yml
+++ b/.github/workflows/release-e2e-tests.yml
@@ -41,12 +41,12 @@ jobs:
     name: Setup Test Environment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -66,10 +66,10 @@ jobs:
     needs: [setup-test-environment]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: patch-release-results
           path: ${{ env.TEST_RESULTS_DIR }}/patch-release-*.json
@@ -95,10 +95,10 @@ jobs:
     needs: [setup-test-environment]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: minor-release-results
           path: ${{ env.TEST_RESULTS_DIR }}/minor-release-*.json
@@ -124,10 +124,10 @@ jobs:
     needs: [setup-test-environment]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: major-release-results
           path: ${{ env.TEST_RESULTS_DIR }}/major-release-*.json
@@ -153,10 +153,10 @@ jobs:
     needs: [setup-test-environment]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: error-handling-results
           path: ${{ env.TEST_RESULTS_DIR }}/error-handling-*.json
@@ -182,10 +182,10 @@ jobs:
     needs: [setup-test-environment]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -201,7 +201,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rollback-results
           path: ${{ env.TEST_RESULTS_DIR }}/rollback-*.json
@@ -211,10 +211,10 @@ jobs:
     needs: [setup-test-environment]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -230,7 +230,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sequential-releases-results
           path: ${{ env.TEST_RESULTS_DIR }}/sequential-releases-*.json
@@ -247,10 +247,10 @@ jobs:
       - scenario-sequential-releases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -258,7 +258,7 @@ jobs:
         run: mkdir -p "${{ env.TEST_RESULTS_DIR }}"
 
       - name: Download all test result artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.TEST_RESULTS_DIR }}/artifacts
 
@@ -269,7 +269,7 @@ jobs:
           TEST_RESULTS_DIR: ${{ env.TEST_RESULTS_DIR }}
 
       - name: Upload consolidated test summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: release-e2e-test-summary
@@ -277,7 +277,7 @@ jobs:
 
       - name: Comment PR with test results
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "lts/*"
       - name: Install
@@ -32,11 +32,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: develop
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "lts/*"
       - name: Install

--- a/.github/workflows/reporting.yml
+++ b/.github/workflows/reporting.yml
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           cache: 'npm'
@@ -142,10 +142,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           cache: 'npm'
@@ -232,7 +232,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Find stale reports
         id: stale
@@ -280,7 +280,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Update main README
         if: github.event.inputs.dry_run != 'true'

--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -14,10 +14,10 @@ jobs:
   reviewer:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 

--- a/.github/workflows/template-enforcement.yml
+++ b/.github/workflows/template-enforcement.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate issue body against required template sections
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- template-enforcement -->';
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Guard against closing incomplete issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- template-enforcement -->';
@@ -309,7 +309,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Validate merged PR body on push to develop
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { validatePullRequestBody } = require('./scripts/validation/template-helpers.cjs');

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,8 +10,8 @@ jobs:
     env:
       HUSKY: '0'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
       - run: node --version && npm --version

--- a/.github/workflows/validate-blocking-issue-before-close.yml
+++ b/.github/workflows/validate-blocking-issue-before-close.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if issue still blocks other open issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- validate-blocking-issue -->';

--- a/.github/workflows/validate-blocking-status-before-close.yml
+++ b/.github/workflows/validate-blocking-status-before-close.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if issue has unclosed blockers
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- validate-blocking-status -->';

--- a/.github/workflows/validate-dor-dod-sections.yml
+++ b/.github/workflows/validate-dor-dod-sections.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload validation report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dor-dod-validation-report
           path: dor-dod-validation-*.json

--- a/.github/workflows/validate-issue-dod-before-close.yml
+++ b/.github/workflows/validate-issue-dod-before-close.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate DoD checklist completion before allowing close
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- validate-issue-dod -->';

--- a/.github/workflows/validate-mermaid-pr.yml
+++ b/.github/workflows/validate-mermaid-pr.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Post PR comment with results
         if: github.event_name == 'pull_request' && steps.has_diagrams.outputs.result == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const syntaxOk    = '${{ steps.results.outputs.syntax_ok }}'   === 'true';
@@ -216,7 +216,7 @@ jobs:
 
       - name: Upload validation reports
         if: always() && steps.has_diagrams.outputs.result == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mermaid-validation-reports-${{ github.run_number }}
           path: |

--- a/.github/workflows/validate-pr-template.yml
+++ b/.github/workflows/validate-pr-template.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Validate pull request body against required template sections
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { validatePullRequestBody } = require('./scripts/validation/template-helpers.cjs');

--- a/.github/workflows/validate-project-linking.yml
+++ b/.github/workflows/validate-project-linking.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Node dependencies
         run: npm ci
@@ -115,7 +115,7 @@ jobs:
 
       - name: Comment PR with validation results
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const projectsFound = '${{ steps.check-linking.outputs.projects_found }}';


### PR DESCRIPTION
## Summary
Targets #2351 (release/v1.0.0).

- `metadata-governance.yml` checked out the PR submitter's fork branch (`github.event.pull_request.head.ref`) under `pull_request_target` while holding a token scoped `issues:write`/`pull-requests:write`/`repository-projects:write`, then executed scripts from that checkout. A PR could edit those scripts to run with that token — the classic "pwn request" pattern. Per GitHub's [securely-using-pull_request_target](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target) guidance, removed the `repository:`/`ref:` override so the checkout always resolves to the trusted base branch, matching the safe pattern already used correctly in `openspec-progress-phase.yml` elsewhere in this same release.
- Verified every pinned action version across all 55 workflow files against each action's actual latest release (via the GitHub API, not assumption) and bumped anything behind: `checkout` v4→v7, `setup-node` v3/v4→v7, `upload-artifact` v3/v4→v7, `download-artifact` v4→v8, `github-script` v7→v9, `create-github-app-token` v2→v3, `labeler` v5→v7, `tj-actions/changed-files` v46→v47, `add-to-project` v1.0.2→v2.0.0. Checked each project's release notes first — all are Node-runtime/feature bumps, no breaking API changes for how these workflows use them.
- Left alone: actions already on latest (`checkout`/`create-github-app-token` pinned by SHA with version comments — already resolve to current), `deploy-pages`/`upload-pages-artifact`/`codecov-action`/`slack-github-action`/`lychee-action`/`mergify-ci` (already latest major), `titoportas/update-project-fields@v0.1.0` (unmaintained since 2022, nothing newer exists).

## Test plan
- [ ] CI on this branch passes
- [ ] Confirm `metadata-governance.yml`'s issue-type-sync path (native type sync via `LS_APP_PRIVATE_KEY`) still fires correctly on `issues` events — untouched by this change but worth re-verifying end to end