### PR TITLE
fix(mergify): scope auto_merge_conditions to the intended bot authors only

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -75,4 +75,17 @@ pull_request_rules:
 
 merge_protections_settings:
   reporting_method: check-runs
-  auto_merge_conditions: true
+  # `true` here means unconditional auto-merge of ANY mergeable PR, for ANY
+  # author, on ANY base branch, the moment GitHub branch protection is
+  # satisfied (see https://docs.mergify.com/merge-protections/auto-merge/).
+  # Every pull_request_rule above deliberately scopes auto-merge to specific
+  # bot authors (dependabot/imgbot/lightspeed-bot) on `develop` only, gated
+  # by `check-success=All Checks Passed` — but this blanket setting bypassed
+  # all of that scoping. Combined with release/v1.0.0 having no branch
+  # protection at all, it auto-merged human/agent-authored PRs against the
+  # release branch within seconds of opening, before CI had even finished.
+  # Restricting the condition list to the same three bot identities used
+  # above restores the intended scope: only they get unconditional
+  # auto-merge, everyone else must merge manually.
+  auto_merge_conditions:
+    - author~=^(dependabot\[bot\]|app/dependabot|imgbot\[bot\]|app/imgbot|lightspeed-bot)$


### PR DESCRIPTION
## Linked issues

Relates to #2351.

## Changelog

### Fixed
- `.github/mergify.yml`'s `merge_protections_settings.auto_merge_conditions: true` was unconditionally auto-merging every mergeable PR against every branch, regardless of author — bypassing the author/base/check scoping written into all three `pull_request_rules` in the same file. Combined with `release/v1.0.0` having no branch protection, this squash-merged #2359 and #2360 within 20-27 seconds of opening, before CI had finished (one CI-discovered fix had to be re-submitted as a separate PR because the first landed too fast to receive it). Restricted `auto_merge_conditions` to the same bot-author condition already used throughout this file (dependabot/imgbot/lightspeed-bot), matching its evident original intent.

## Risk Assessment

**Risk Level:** Medium

**Potential Impact:** This changes merge automation behaviour repo-wide. After this merges, PRs from human/agent authors will no longer auto-merge and will require an explicit merge action — this is the intended fix, but worth confirming it doesn't block any other automation that relied on the old blanket behaviour.

**Mitigation Steps:** Scoped narrowly to the one setting causing the issue; did not touch the three existing `pull_request_rules`, which already had correct, deliberate scoping and continue to work identically for dependabot/imgbot/lightspeed-bot on `develop`.

## How to Test

### Prerequisites
None.

### Test Steps
1. Open a PR from a non-bot author against any branch and confirm it does NOT auto-merge, even once checks pass.
2. Confirm a dependabot/imgbot/lightspeed-bot PR against `develop` still auto-merges as before once `check-success=All Checks Passed`.

### Expected Results
Only the three intended bot flows retain auto-merge; everything else requires a manual merge.

### Edge Cases to Verify
- [x] YAML validity confirmed locally before push
- [ ] Mergify's own "Configuration changed" check passes on this PR (will confirm once CI reports back)

### Checklist (Global DoD / PR)
- [x] Root cause confirmed via Mergify's own merge-queue status comments (not guessed) on #2359/#2360
- [x] Change scoped to the single setting responsible, no unrelated config touched
