### PR TITLE
fix(workflows): remove job name override breaking main's required status check

### DIFF
--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -15,7 +15,11 @@ concurrency:
 
 jobs:
   validate-release-branch:
-    name: validate-release-branch
+    # Deliberately no `name:` override: main's branch protection requires
+    # the check "Main Branch Guard / validate-release-branch" (the default
+    # <workflow name> / <job id> format), but the explicit override below
+    # produced a bare "validate-release-branch" context instead — a string
+    # that could never match, permanently blocking every release PR to main.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Linked issues

Relates to #2351. This is what was actually blocking it from becoming mergeable.

## Changelog

### Fixed
- `main-branch-guard.yml`'s `validate-release-branch` job explicitly overrode its display name to `validate-release-branch`, but main's branch protection requires the check `Main Branch Guard / validate-release-branch` (GitHub's default `<workflow name> / <job id>` format). The two strings can never match, so this permanently blocked every release PR to `main` from becoming mergeable, regardless of approval or the job's own pass/fail result. Removed the override.

## Risk Assessment

**Risk Level:** Low

**Potential Impact:** Only affects how this one check's name is reported to branch protection; no change to what the job actually validates.

**Mitigation Steps:** Confirmed the job's validation logic is untouched — only the `name:` line was removed.

## How to Test / Test Plan

Once merged, #2351's `mergeStateStatus` should move from `BLOCKED` to `CLEAN` (already approved, already passing its one required check by content — just reported under the wrong name).

### Checklist (Global DoD / PR)
- [x] Confirmed via GitHub API that the required context string is `Main Branch Guard / validate-release-branch` and the reported context was the mismatched `validate-release-branch`
