### PR TITLE
fix(workflows): actually match main's required check name this time

### DIFF
--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -15,11 +15,14 @@ concurrency:
 
 jobs:
   validate-release-branch:
-    # Deliberately no `name:` override: main's branch protection requires
-    # the check "Main Branch Guard / validate-release-branch" (the default
-    # <workflow name> / <job id> format), but the explicit override below
-    # produced a bare "validate-release-branch" context instead — a string
-    # that could never match, permanently blocking every release PR to main.
+    # GitHub does not auto-prefix a check-run name with the workflow name
+    # for a plain job — it just reports the job id/name as-is. main's branch
+    # protection requires the exact context "Main Branch Guard /
+    # validate-release-branch", so the name must be set to that literal
+    # string, not left as (or overridden to) the bare job id. A prior fix
+    # that just removed the override to "validate-release-branch" changed
+    # nothing, since that string was already identical to the job id.
+    name: "Main Branch Guard / validate-release-branch"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Linked issues

Relates to #2351, follow-up to #2363 which didn't actually fix the problem.

## Changelog

### Fixed
- #2363 removed a `name: validate-release-branch` override on the `validate-release-branch` job, on the theory that GitHub auto-prefixes check names with the workflow name. It doesn't for a plain job — confirmed via the GitHub API after #2363 merged, the check still reported as bare `validate-release-branch`, identical to before. Sets `name: "Main Branch Guard / validate-release-branch"` explicitly, matching the literal string main's branch protection requires.

## Risk Assessment

**Risk Level:** Low

**Potential Impact:** Only changes the reported check-run name, no change to validation logic.

**Mitigation Steps:** Verified locally that the resulting YAML is valid before pushing.

## How to Test / Test Plan

Confirm via the GitHub API that the check-run name on the next PR against `main` is exactly `Main Branch Guard / validate-release-branch`, and that #2351's `mergeStateStatus` clears to `CLEAN`.

### Checklist (Global DoD / PR)
- [x] Confirmed the previous attempt's failure via API before writing this fix
- [x] YAML validity checked locally
